### PR TITLE
Monica/fix ui spacing

### DIFF
--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		50A19BAE1E4C214000AD6768 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A19BAD1E4C214000AD6768 /* HomeViewController.swift */; };
 		9CAD63CB367551D7A8B32C6E /* Pods_TCAT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69224A160B2B078827D28A1 /* Pods_TCAT.framework */; };
 		BF0002221FB37D0A00773109 /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0002211FB37D0A00773109 /* LoadingIndicator.swift */; };
-		BF101FE21F93D9BB00C58769 /* LiveIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF101FE11F93D9BB00C58769 /* LiveIndicator.swift */; };
 		BF1209FB1F7759C200A7C930 /* BusLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1209FA1F7759C200A7C930 /* BusLocationView.swift */; };
 		BF456E0320489990005C611D /* BusLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF456E0220489990005C611D /* BusLocation.swift */; };
 		BF5CBAD11FCE6CCE00478C6F /* RouteDetail+DrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5CBAD01FCE6CCE00478C6F /* RouteDetail+DrawerViewController.swift */; };
@@ -54,6 +53,7 @@
 		DD3D9C211F94297100B164D4 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3D9C201F94297100B164D4 /* Reachability.swift */; };
 		DD3D9C341F942CF000B164D4 /* CoordinateVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3D9C331F942CF000B164D4 /* CoordinateVisitor.swift */; };
 		DD3D9C361F945F2A00B164D4 /* RPCircularProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3D9C351F945F2A00B164D4 /* RPCircularProgress.swift */; };
+		DD50B8E3207A9DD600E1DE74 /* LiveIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD50B8E2207A9DD500E1DE74 /* LiveIndicator.swift */; };
 		DD5D233C1E6367A100F8DECE /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5D233B1E6367A100F8DECE /* Time.swift */; };
 		DD623C8D1E6D0585005ED004 /* SFText-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = DD623C8A1E6D0585005ED004 /* SFText-Medium.otf */; };
 		DD623C8E1E6D0585005ED004 /* SFText-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = DD623C8B1E6D0585005ED004 /* SFText-Regular.otf */; };
@@ -125,7 +125,6 @@
 		8236DFFA6C5F3AB1E6E1B0E4 /* Pods-TCATTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCATTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TCATTests/Pods-TCATTests.debug.xcconfig"; sourceTree = "<group>"; };
 		97F81CAA39621F2304CFA763 /* Pods-TCATUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCATUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TCATUITests/Pods-TCATUITests.release.xcconfig"; sourceTree = "<group>"; };
 		BF0002211FB37D0A00773109 /* LoadingIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoadingIndicator.swift; path = Views/LoadingIndicator.swift; sourceTree = "<group>"; };
-		BF101FE11F93D9BB00C58769 /* LiveIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LiveIndicator.swift; path = Views/LiveIndicator.swift; sourceTree = "<group>"; };
 		BF1209FA1F7759C200A7C930 /* BusLocationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BusLocationView.swift; path = Views/BusLocationView.swift; sourceTree = "<group>"; };
 		BF456E0220489990005C611D /* BusLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BusLocation.swift; path = Model/BusLocation.swift; sourceTree = "<group>"; };
 		BF5CBAD01FCE6CCE00478C6F /* RouteDetail+DrawerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "RouteDetail+DrawerViewController.swift"; path = "Controllers/RouteDetail+DrawerViewController.swift"; sourceTree = "<group>"; };
@@ -155,6 +154,7 @@
 		DD3D9C201F94297100B164D4 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = Utilities/Reachability.swift; sourceTree = "<group>"; };
 		DD3D9C331F942CF000B164D4 /* CoordinateVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CoordinateVisitor.swift; path = Utilities/CoordinateVisitor.swift; sourceTree = "<group>"; };
 		DD3D9C351F945F2A00B164D4 /* RPCircularProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RPCircularProgress.swift; path = Views/RPCircularProgress.swift; sourceTree = "<group>"; };
+		DD50B8E2207A9DD500E1DE74 /* LiveIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LiveIndicator.swift; path = "/Users/Monica/Documents/18Sp/Cornell AppDev/tcat-ios/TCAT/Views/LiveIndicator.swift"; sourceTree = "<absolute>"; };
 		DD5D233B1E6367A100F8DECE /* Time.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Time.swift; path = Utilities/Time.swift; sourceTree = "<group>"; };
 		DD623C8A1E6D0585005ED004 /* SFText-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SFText-Medium.otf"; path = "Supporting Files/SFText-Medium.otf"; sourceTree = "<group>"; };
 		DD623C8B1E6D0585005ED004 /* SFText-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "SFText-Regular.otf"; path = "Supporting Files/SFText-Regular.otf"; sourceTree = "<group>"; };
@@ -370,13 +370,13 @@
 		DD2F98951E50D8E60005F6BC /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				DD50B8E2207A9DD500E1DE74 /* LiveIndicator.swift */,
 				DD16B8E41E7046390089B7B2 /* BusIcon.swift */,
 				BF1209FA1F7759C200A7C930 /* BusLocationView.swift */,
 				DDBCD5E61E989E5800014641 /* Circle.swift */,
 				DDBFEA9E1E787008002BBD96 /* DatePickerView.swift */,
 				DDB49CA11E88584B00A99C35 /* DetailIconView.swift */,
 				DC2E96451FC21B29009955C6 /* HeaderView.swift */,
-				BF101FE11F93D9BB00C58769 /* LiveIndicator.swift */,
 				BF0002211FB37D0A00773109 /* LoadingIndicator.swift */,
 				DDA134441EC6A8CB00460B18 /* RouteLine.swift */,
 				DDE0A9301F096A3E005CD01C /* RouteDiagram.swift */,
@@ -771,7 +771,6 @@
 				DD659C8A20508E1B00506BAC /* WalkWithDistanceIcon.swift in Sources */,
 				DD36A7001F66378C00E4789E /* PlaceResult.swift in Sources */,
 				BF73F0F31F60B0BD003B479D /* LocationObject.swift in Sources */,
-				BF101FE21F93D9BB00C58769 /* LiveIndicator.swift in Sources */,
 				BFF41EB2204365E800E0696B /* SummaryView.swift in Sources */,
 				DDB49CA21E88584B00A99C35 /* DetailIconView.swift in Sources */,
 				BF0002221FB37D0A00773109 /* LoadingIndicator.swift in Sources */,
@@ -796,6 +795,7 @@
 				BF6095271FD7091B0013E538 /* CustomNavigationController.swift in Sources */,
 				BF5CBAD11FCE6CCE00478C6F /* RouteDetail+DrawerViewController.swift in Sources */,
 				DDB49C991E8857E000A99C35 /* SmallDetailTableViewCell.swift in Sources */,
+				DD50B8E3207A9DD600E1DE74 /* LiveIndicator.swift in Sources */,
 				DDBFEAA01E787008002BBD96 /* DatePickerView.swift in Sources */,
 				DD36A6FF1F66378C00E4789E /* BusStop.swift in Sources */,
 				DDC83CA51E52B0D400D4EDDF /* RouteTableViewCell.swift in Sources */,

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -164,14 +164,14 @@ class RouteTableViewCell: UITableViewCell {
     
     // MARK: Add subviews
     
-    func addSubviews() {
-        //        routeDiagram.addSubviews()
+    func addSubviewsToRouteDiagram() {
+        routeDiagram.addSubviews()
     }
 
     // MARK: Constraints
 
-    func activateSubviewsConstraints() {
-//        routeDiagram.positionSubviews()
+    func activateRouteDiagramConstraints() {
+        routeDiagram.positionSubviews()
     }
     
     private func activateConstraints() {
@@ -254,17 +254,6 @@ class RouteTableViewCell: UITableViewCell {
         cellSeparator.accessibilityIdentifier = "cellSeparator"
     }
     
-    // MARK: Reuse
-    
-    override func prepareForReuse() {
-        //        routeDiagram.prepareForReuse()
-        
-        hideLiveElements()
-        
-        // stop timer
-        timer?.invalidate()
-    }
-    
     // MARK: Get Data
     
     private func getDepartureAndArrivalTimes(fromRoute route: Route) -> (departureTime: Date, arrivalTime: Date) {
@@ -307,6 +296,17 @@ class RouteTableViewCell: UITableViewCell {
         
     }
     
+    // MARK: Reuse
+    
+    override func prepareForReuse() {
+        routeDiagram.prepareForReuse()
+        
+        hideLiveElements()
+        
+        // stop timer
+        timer?.invalidate()
+    }
+    
     // MARK: Set Data
     
     func setData(_ route: Route) {
@@ -319,7 +319,7 @@ class RouteTableViewCell: UITableViewCell {
         
         setDepartureTimeAndLiveElements(withRoute: route)
         
-        //        routeDiagram.setData(withDirections: route.rawDirections, withTravelDistance: route.travelDistance, withWalkingRoute: route.isRawWalkingRoute())
+        routeDiagram.setData(withDirections: route.rawDirections, withTravelDistance: route.travelDistance, withWalkingRoute: route.isRawWalkingRoute())
     }
     
     private func setDepartureTimeAndLiveElements(withRoute route: Route) {

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -214,23 +214,12 @@ class RouteTableViewCell: UITableViewCell {
     }
     
     private func setTranslatesAutoresizingMaskIntoConstraints() {
-        timesStackView.translatesAutoresizingMaskIntoConstraints = false
-        travelTimeLabel.translatesAutoresizingMaskIntoConstraints = false
-    
-        departureStackView.translatesAutoresizingMaskIntoConstraints = false
-        departureTimeLabel.translatesAutoresizingMaskIntoConstraints = false
-        arrowImageView.translatesAutoresizingMaskIntoConstraints = false
-    
-        liveStackView.translatesAutoresizingMaskIntoConstraints = false
-        liveLabel.translatesAutoresizingMaskIntoConstraints = false
-        liveIndicatorView.translatesAutoresizingMaskIntoConstraints = false
-        stretchyFillerView.translatesAutoresizingMaskIntoConstraints = false
-    
-        verticalStackView.translatesAutoresizingMaskIntoConstraints = false
-        topBorder.translatesAutoresizingMaskIntoConstraints = false
-        routeDiagram.translatesAutoresizingMaskIntoConstraints = false
-        bottomBorder.translatesAutoresizingMaskIntoConstraints = false
-        cellSeparator.translatesAutoresizingMaskIntoConstraints = false
+        let subviews = [timesStackView, travelTimeLabel,
+                        departureStackView, departureTimeLabel, arrowImageView,
+                        liveStackView, liveLabel, liveIndicatorView, stretchyFillerView,
+                        verticalStackView, topBorder, routeDiagram, bottomBorder, cellSeparator]
+        
+        subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
     }
     
     /// For debugging constraint errors

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -70,36 +70,21 @@ class RouteTableViewCell: UITableViewCell {
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         departureTimeLabel = UILabel()
         arrowImageView = UIImageView(image: #imageLiteral(resourceName: "side-arrow"))
-        
         departureStackView = UIStackView(arrangedSubviews: [departureTimeLabel, arrowImageView])
-        departureStackView.axis = .horizontal
-        departureStackView.spacing = spaceBtnDepartureElements
         
         travelTimeLabel = UILabel()
-
         timesStackView = UIStackView(arrangedSubviews: [travelTimeLabel, departureStackView])
-        timesStackView.axis = .horizontal
-        timesStackView.alignment = .center
         
         liveLabel = UILabel()
         liveIndicatorView = LiveIndicator(size: .small, color: .clear)
         stretchyFillerView = UIView()
-        
-        //  make stretchyFillerView’s horizontal content-hugging priority is lower than the label’s so it stretches to fill extra space
-        stretchyFillerView.setContentHuggingPriority(liveLabel.contentHuggingPriority(for: .horizontal) - 1, for: .horizontal)
-        
         liveStackView = UIStackView(arrangedSubviews: [liveLabel, liveIndicatorView, stretchyFillerView])
-        liveStackView.axis = .horizontal
-        liveStackView.alignment = .lastBaseline
-        liveStackView.spacing = spaceBtnLiveElements
         
         topBorder = UIView()
         routeDiagram = RouteDiagram()
         bottomBorder = UIView()
         cellSeparator = UIView()
-        
         verticalStackView = UIStackView(arrangedSubviews: [timesStackView, liveStackView, routeDiagram])
-        verticalStackView.axis = .vertical
         
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
@@ -112,9 +97,6 @@ class RouteTableViewCell: UITableViewCell {
         contentView.addSubview(verticalStackView)
         contentView.addSubview(bottomBorder)
         contentView.addSubview(cellSeparator)
-        
-        verticalStackView.layoutMargins = UIEdgeInsetsMake(topMargin, leftMargin, bottomMargin, rightMargin)
-        verticalStackView.isLayoutMarginsRelativeArrangement = true
         
         activateConstraints()
     }
@@ -130,32 +112,42 @@ class RouteTableViewCell: UITableViewCell {
     // MARK: Style
 
     private func styleVerticalStackView() {
+        verticalStackView.axis = .vertical
+        verticalStackView.layoutMargins = UIEdgeInsetsMake(topMargin, leftMargin, bottomMargin, rightMargin)
+        verticalStackView.isLayoutMarginsRelativeArrangement = true
+
         styleTimesStackView()
         styleLiveStackView()
     }
     
     private func styleTimesStackView() {
-        styleTravelTime()
-        styleDepartureElements()
-    }
-    
-    private func styleLiveStackView() {
-        styleLiveElements()
-    }
-    
-    private func styleTravelTime() {
+        timesStackView.axis = .horizontal
+        timesStackView.alignment = .center
+        
         travelTimeLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 16.0)
         travelTimeLabel.textColor = .primaryTextColor
+        
+        styleDepartureStackView()
     }
-
-    private func styleLiveElements() {
-        liveLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 14.0)
-    }
-
-    private func styleDepartureElements() {
+    
+    private func styleDepartureStackView() {
+        departureStackView.axis = .horizontal
+        departureStackView.spacing = spaceBtnDepartureElements
+        
         departureTimeLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 14.0)
         departureTimeLabel.textColor = .primaryTextColor
         arrowImageView.tintColor = .mediumGrayColor
+    }
+    
+    private func styleLiveStackView() {
+        //  make stretchyFillerView’s horizontal content-hugging priority is lower than the label’s so it stretches to fill extra space
+        stretchyFillerView.setContentHuggingPriority(liveLabel.contentHuggingPriority(for: .horizontal) - 1, for: .horizontal)
+        
+        liveStackView.axis = .horizontal
+        liveStackView.alignment = .lastBaseline
+        liveStackView.spacing = spaceBtnLiveElements
+        
+        liveLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 14.0)
     }
 
     private func styleTopBorder() {

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -184,33 +184,33 @@ class RouteTableViewCell: UITableViewCell {
             topBorder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             topBorder.heightAnchor.constraint(equalToConstant: cellBorderHeight),
             topBorder.bottomAnchor.constraint(equalTo: verticalStackView.topAnchor)
-            ])
+        ])
         
         NSLayoutConstraint.activate([
             verticalStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             verticalStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             verticalStackView.bottomAnchor.constraint(equalTo: bottomBorder.topAnchor)
-            ])
+        ])
         
         NSLayoutConstraint.activate([
             bottomBorder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             bottomBorder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             bottomBorder.heightAnchor.constraint(equalToConstant: cellBorderHeight),
             bottomBorder.bottomAnchor.constraint(equalTo: cellSeparator.topAnchor)
-            ])
+        ])
         
         NSLayoutConstraint.activate([
             cellSeparator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             cellSeparator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             cellSeparator.heightAnchor.constraint(equalToConstant: cellSeparatorHeight),
             cellSeparator.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-            ])
+        ])
         
         NSLayoutConstraint.activate([
             arrowImageView.heightAnchor.constraint(equalToConstant: arrowImageViewHeight),
             arrowImageView.widthAnchor.constraint(equalToConstant: arrowImageViewWidth),
             arrowImageView.centerYAnchor.constraint(equalTo: departureTimeLabel.centerYAnchor)
-            ])
+        ])
     }
     
     private func setTranslatesAutoresizingMaskIntoConstraints() {
@@ -257,7 +257,7 @@ class RouteTableViewCell: UITableViewCell {
     // MARK: Get Data
     
     private func getDepartureAndArrivalTimes(fromRoute route: Route) -> (departureTime: Date, arrivalTime: Date) {
-        if let firstDepartDirection = route.getFirstDepartRawDirection(), let lastDepartDirection = route.getLastDepartRawDirection(){
+        if let firstDepartDirection = route.getFirstDepartRawDirection(), let lastDepartDirection = route.getLastDepartRawDirection() {
             return (departureTime: firstDepartDirection.startTime, arrivalTime: lastDepartDirection.endTime)
         }
         
@@ -450,7 +450,7 @@ class RouteTableViewCell: UITableViewCell {
         arrowImageView.tintColor = .primaryTextColor
     }
     
-    private func setTravelTime(withDepartureTime departureTime: Date, withArrivalTime arrivalTime: Date){
+    private func setTravelTime(withDepartureTime departureTime: Date, withArrivalTime arrivalTime: Date) {
         travelTimeLabel.text = "\(Time.timeString(from: departureTime)) - \(Time.timeString(from: arrivalTime))"
     }
     

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -57,7 +57,7 @@ class RouteTableViewCell: UITableViewCell {
     let rightMargin: CGFloat = 12
     
     let cellBorderHeight: CGFloat = 0.75
-    let cellSeparatorHeight: CGFloat = 8.0
+    let cellSeparatorHeight: CGFloat = 6.0
     
     let spaceBtnDepartureElements: CGFloat = 4
     let arrowImageViewHeight: CGFloat = 11.5
@@ -164,14 +164,14 @@ class RouteTableViewCell: UITableViewCell {
     
     // MARK: Add subviews
     
-    func addSubviewsToRouteDiagram() {
+    func addRouteDiagramSubviews() {
         routeDiagram.addSubviews()
     }
 
-    // MARK: Constraints
+    // MARK: Activate constraints
 
     func activateRouteDiagramConstraints() {
-        routeDiagram.positionSubviews()
+        routeDiagram.activateConstraints()
     }
     
     private func activateConstraints() {
@@ -301,7 +301,7 @@ class RouteTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         routeDiagram.prepareForReuse()
         
-        hideLiveElements()
+        hideLiveElements(animate: false)
         
         // stop timer
         timer?.invalidate()
@@ -400,7 +400,7 @@ class RouteTableViewCell: UITableViewCell {
             
         case .noDelay(date: _):
             if !liveStackView.isHidden {
-                hideLiveElements()
+                hideLiveElements(animate: true)
             }
             
         }
@@ -413,8 +413,12 @@ class RouteTableViewCell: UITableViewCell {
         }
     }
     
-    private func hideLiveElements() {
-        UIView.animate(withDuration: 0.3) {
+    private func hideLiveElements(animate: Bool) {
+        if animate {
+            UIView.animate(withDuration: 0.3) {
+                self.liveStackView.isHidden = true
+            }
+        } else {
             self.liveStackView.isHidden = true
         }
     }

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -22,7 +22,7 @@ class RouteTableViewCell: UITableViewCell {
 
     // MARK: Data vars
     
-    let identifier: String = "routeCell"
+    static let identifier: String = "routeCell"
     var route: Route?
     
     // MARK: Network vars
@@ -31,107 +31,241 @@ class RouteTableViewCell: UITableViewCell {
 
     // MARK: View vars
 
-    var travelTimeLabel: UILabel = UILabel()
-    var liveIndicatorView: LiveIndicator = LiveIndicator(size: .small, color: .clear)
-    var liveLabel: UILabel = UILabel()
-    var departureTimeLabel: UILabel = UILabel()
-    var arrowImageView: UIImageView = UIImageView(image: #imageLiteral(resourceName: "side-arrow"))
-
-    var routeDiagram: RouteDiagram = RouteDiagram()
-
-    var topBorder: UIView = UIView()
-    var bottomBorder: UIView = UIView()
-    var cellSeperator: UIView = UIView()
+    var timesStackView: UIStackView
+    var travelTimeLabel: UILabel
+    
+    var departureStackView: UIStackView
+    var departureTimeLabel: UILabel
+    var arrowImageView: UIImageView
+    
+    var liveStackView: UIStackView
+    var liveLabel: UILabel
+    var liveIndicatorView: LiveIndicator
+    var stretchyFillerView: UIView
+    
+    var verticalStackView: UIStackView
+    var topBorder: UIView
+    var routeDiagram: RouteDiagram
+    var bottomBorder: UIView
+    var cellSeparator: UIView
 
     // MARK: Spacing vars
-
-    let timeLabelLeftSpaceFromSuperview: CGFloat = 18.0
-    let timeLabelVerticalSpaceFromSuperview: CGFloat = 18.0
     
-    let liveLabelHorizontalSpaceFromLiveIndicator: CGFloat = 4.0
-    
-    let arrowImageViewRightSpaceFromSuperview: CGFloat = 12.0
-    let departureLabelSpaceFromArrowImageView: CGFloat = 8.0
-    
-    let timeLabelAndRouteDiagramVerticalSpace: CGFloat = 32.5
+    let leftMargin: CGFloat =  16
+    let topMargin: CGFloat = 16
+    let bottomMargin: CGFloat = 16
+    let rightMargin: CGFloat = 12
     
     let cellBorderHeight: CGFloat = 0.75
     let cellSeparatorHeight: CGFloat = 8.0
     
-    let routeDiagramAndCellSeparatorVerticalSpace: CGFloat = 16.5
+    let spaceBtnDepartureElements: CGFloat = 4
+    let arrowImageViewHeight: CGFloat = 11.5
+    let arrowImageViewWidth: CGFloat = 6
+    
+    let spaceBtnLiveElements: CGFloat = 2
 
     // MARK: Init
 
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        departureTimeLabel = UILabel()
+        arrowImageView = UIImageView(image: #imageLiteral(resourceName: "side-arrow"))
+        
+        departureStackView = UIStackView(arrangedSubviews: [departureTimeLabel, arrowImageView])
+        departureStackView.axis = .horizontal
+        departureStackView.spacing = spaceBtnDepartureElements
+        
+        travelTimeLabel = UILabel()
+
+        timesStackView = UIStackView(arrangedSubviews: [travelTimeLabel, departureStackView])
+        timesStackView.axis = .horizontal
+        timesStackView.alignment = .center
+        
+        liveLabel = UILabel()
+        liveIndicatorView = LiveIndicator(size: .small, color: .clear)
+        stretchyFillerView = UIView()
+        
+        //  make stretchyFillerView’s horizontal content-hugging priority is lower than the label’s so it stretches to fill extra space
+        stretchyFillerView.setContentHuggingPriority(liveLabel.contentHuggingPriority(for: .horizontal) - 1, for: .horizontal)
+        
+        liveStackView = UIStackView(arrangedSubviews: [liveLabel, liveIndicatorView, stretchyFillerView])
+        liveStackView.axis = .horizontal
+        liveStackView.alignment = .lastBaseline
+        liveStackView.spacing = spaceBtnLiveElements
+        
+        topBorder = UIView()
+        routeDiagram = RouteDiagram()
+        bottomBorder = UIView()
+        cellSeparator = UIView()
+        
+        verticalStackView = UIStackView(arrangedSubviews: [timesStackView, liveStackView, routeDiagram])
+        verticalStackView.axis = .vertical
+        
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        styleTravelTime()
-        styleLiveElements()
-        styleDepartureTime()
         styleTopBorder()
-
-        positionTravelTime()
-        positionLiveLabel(usingTravelTime: travelTimeLabel)
-        positionLiveIndicatorView(usingTravelTime: travelTimeLabel)
-        positionDepartureTimeVertically(usingTravelTime: travelTimeLabel)
-        positionArrowVertically(usingDepartureTime: departureTimeLabel)
-        positionTopBorder()
+        styleVerticalStackView()
+        styleBottomBorder()
+        styleCellSeparator()
         
-        contentView.addSubview(travelTimeLabel)
-        contentView.addSubview(liveIndicatorView)
-        contentView.addSubview(liveLabel)
-        contentView.addSubview(departureTimeLabel)
-        contentView.addSubview(arrowImageView)
         contentView.addSubview(topBorder)
+        contentView.addSubview(verticalStackView)
+        contentView.addSubview(bottomBorder)
+        contentView.addSubview(cellSeparator)
+        
+        verticalStackView.layoutMargins = UIEdgeInsetsMake(topMargin, leftMargin, bottomMargin, rightMargin)
+        verticalStackView.isLayoutMarginsRelativeArrangement = true
+        
+        activateConstraints()
     }
 
-    init() {
-        super.init(style: UITableViewCellStyle.default, reuseIdentifier: identifier)
-    }
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
+    convenience init() {
+        self.init(style: UITableViewCellStyle.default, reuseIdentifier: RouteTableViewCell.identifier)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: Style
 
-    func heightForCell(withNumOfStops numOfStops: Int, withNumOfWalkLines numOfWalkLines: Int) -> CGFloat {
-        
-        let numOfSolidStopDots = numOfStops - 1
-        let numOfRouteLines = numOfSolidStopDots
-        let numOfBusLines = numOfRouteLines - numOfWalkLines
-        
-        let timeLabelHeight: CGFloat = 17.0
-        
-        let headerHeight = timeLabelVerticalSpaceFromSuperview + timeLabelHeight + timeLabelAndRouteDiagramVerticalSpace
-        
-        let solidStopDotDiameter: CGFloat = Circle(size: .small, style: .solid, color: .tcatBlueColor).frame.height
-        let busLineHeight: CGFloat = RouteDiagram.busLineHeight
-        let walkLineHeight: CGFloat = RouteDiagram.walkLineHeight
-        let destinationDotHeight: CGFloat = Circle(size: .medium, style: .bordered, color: .tcatBlueColor).frame.height
-        
-        let routeDiagramHeight = CGFloat(numOfSolidStopDots) * solidStopDotDiameter +
-                                 CGFloat(numOfBusLines) * busLineHeight +
-                                 CGFloat(numOfWalkLines) * walkLineHeight + destinationDotHeight
-        
-        let stopLabelHeight: CGFloat = 17.0 // add an extra stop label height for if the last label is two-lined
-        let footerHeight = stopLabelHeight + stopLabelHeight + cellSeparatorHeight
-
-        
-        return headerHeight + routeDiagramHeight + footerHeight
-        
+    private func styleVerticalStackView() {
+        styleTimesStackView()
+        styleLiveStackView()
+    }
+    
+    private func styleTimesStackView() {
+        styleTravelTime()
+        styleDepartureElements()
+    }
+    
+    private func styleLiveStackView() {
+        styleLiveElements()
+    }
+    
+    private func styleTravelTime() {
+        travelTimeLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 16.0)
+        travelTimeLabel.textColor = .primaryTextColor
     }
 
+    private func styleLiveElements() {
+        liveLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 14.0)
+    }
+
+    private func styleDepartureElements() {
+        departureTimeLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 14.0)
+        departureTimeLabel.textColor = .primaryTextColor
+        arrowImageView.tintColor = .mediumGrayColor
+    }
+
+    private func styleTopBorder() {
+        topBorder.backgroundColor = .lineDotColor
+    }
+
+    private func styleBottomBorder() {
+        bottomBorder.backgroundColor = .lineDotColor
+    }
+
+    private func styleCellSeparator() {
+        cellSeparator.backgroundColor = .tableBackgroundColor
+    }
+    
+    // MARK: Add subviews
+    
+    func addSubviews() {
+        //        routeDiagram.addSubviews()
+    }
+
+    // MARK: Constraints
+
+    func activateSubviewsConstraints() {
+//        routeDiagram.positionSubviews()
+    }
+    
+    private func activateConstraints() {
+        setTranslatesAutoresizingMaskIntoConstraints()
+        setDebugIdentifiers()
+        
+        NSLayoutConstraint.activate([
+            topBorder.topAnchor.constraint(equalTo: contentView.topAnchor),
+            topBorder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            topBorder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            topBorder.heightAnchor.constraint(equalToConstant: cellBorderHeight),
+            topBorder.bottomAnchor.constraint(equalTo: verticalStackView.topAnchor)
+            ])
+        
+        NSLayoutConstraint.activate([
+            verticalStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            verticalStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            verticalStackView.bottomAnchor.constraint(equalTo: bottomBorder.topAnchor)
+            ])
+        
+        NSLayoutConstraint.activate([
+            bottomBorder.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            bottomBorder.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            bottomBorder.heightAnchor.constraint(equalToConstant: cellBorderHeight),
+            bottomBorder.bottomAnchor.constraint(equalTo: cellSeparator.topAnchor)
+            ])
+        
+        NSLayoutConstraint.activate([
+            cellSeparator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            cellSeparator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            cellSeparator.heightAnchor.constraint(equalToConstant: cellSeparatorHeight),
+            cellSeparator.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            ])
+        
+        NSLayoutConstraint.activate([
+            arrowImageView.heightAnchor.constraint(equalToConstant: arrowImageViewHeight),
+            arrowImageView.widthAnchor.constraint(equalToConstant: arrowImageViewWidth),
+            arrowImageView.centerYAnchor.constraint(equalTo: departureTimeLabel.centerYAnchor)
+            ])
+    }
+    
+    private func setTranslatesAutoresizingMaskIntoConstraints() {
+        timesStackView.translatesAutoresizingMaskIntoConstraints = false
+        travelTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+    
+        departureStackView.translatesAutoresizingMaskIntoConstraints = false
+        departureTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        arrowImageView.translatesAutoresizingMaskIntoConstraints = false
+    
+        liveStackView.translatesAutoresizingMaskIntoConstraints = false
+        liveLabel.translatesAutoresizingMaskIntoConstraints = false
+        liveIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        stretchyFillerView.translatesAutoresizingMaskIntoConstraints = false
+    
+        verticalStackView.translatesAutoresizingMaskIntoConstraints = false
+        topBorder.translatesAutoresizingMaskIntoConstraints = false
+        routeDiagram.translatesAutoresizingMaskIntoConstraints = false
+        bottomBorder.translatesAutoresizingMaskIntoConstraints = false
+        cellSeparator.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    /// For debugging constraint errors
+    private func setDebugIdentifiers() {
+        timesStackView.accessibilityIdentifier = "timesStackView"
+        travelTimeLabel.accessibilityIdentifier = "travelTimeLabel"
+        
+        departureStackView.accessibilityIdentifier = "departureStackView"
+        departureTimeLabel.accessibilityIdentifier = "departureTimeLabel"
+        arrowImageView.accessibilityIdentifier = "arrowImageView"
+        
+        liveStackView.accessibilityIdentifier = "liveStackView"
+        liveLabel.accessibilityIdentifier = "liveLabel"
+        liveIndicatorView.accessibilityIdentifier = "liveIndicatorView"
+        stretchyFillerView.accessibilityIdentifier = "stretchyFillerView"
+        
+        verticalStackView.accessibilityIdentifier = "verticalStackView"
+        topBorder.accessibilityIdentifier = "topBorder"
+        routeDiagram.accessibilityIdentifier = "routeDiagram"
+        bottomBorder.accessibilityIdentifier = "bottomBorder"
+        cellSeparator.accessibilityIdentifier = "cellSeparator"
+    }
+    
     // MARK: Reuse
-
+    
     override func prepareForReuse() {
-        routeDiagram.prepareForReuse()
-
-        routeDiagram.removeFromSuperview()
-        cellSeperator.removeFromSuperview()
-        bottomBorder.removeFromSuperview()
+        //        routeDiagram.prepareForReuse()
         
         hideLiveElements()
         
@@ -140,12 +274,12 @@ class RouteTableViewCell: UITableViewCell {
     }
     
     // MARK: Get Data
-
+    
     private func getDepartureAndArrivalTimes(fromRoute route: Route) -> (departureTime: Date, arrivalTime: Date) {
         if let firstDepartDirection = route.getFirstDepartRawDirection(), let lastDepartDirection = route.getLastDepartRawDirection(){
             return (departureTime: firstDepartDirection.startTime, arrivalTime: lastDepartDirection.endTime)
         }
-            
+        
         return (departureTime: route.departureTime, arrivalTime: route.arrivalTime)
     }
     
@@ -180,9 +314,9 @@ class RouteTableViewCell: UITableViewCell {
         return .noDelay(date: route.departureTime)
         
     }
-
+    
     // MARK: Set Data
-
+    
     func setData(_ route: Route) {
         self.route = route
         
@@ -193,12 +327,12 @@ class RouteTableViewCell: UITableViewCell {
         
         setDepartureTimeAndLiveElements(withRoute: route)
         
-        routeDiagram.setData(withDirections: route.rawDirections, withTravelDistance: route.travelDistance, withWalkingRoute: route.isRawWalkingRoute())
+        //        routeDiagram.setData(withDirections: route.rawDirections, withTravelDistance: route.travelDistance, withWalkingRoute: route.isRawWalkingRoute())
     }
     
     private func setDepartureTimeAndLiveElements(withRoute route: Route) {
         let isWalkingRoute = route.isRawWalkingRoute()
-
+        
         if isWalkingRoute {
             setDepartureTimeToWalking()
             return
@@ -260,24 +394,37 @@ class RouteTableViewCell: UITableViewCell {
             liveLabel.textColor = .liveRedColor
             liveLabel.text = "Late - \(Time.timeString(from: delayedDepartureTime))"
             liveIndicatorView.setColor(to: .liveRedColor)
+            if liveStackView.isHidden {
+                showLiveElements()
+            }
             
         case .onTime(date: _):
             liveLabel.textColor = .liveGreenColor
             liveLabel.text = "On Time"
             liveIndicatorView.setColor(to:.liveGreenColor)
+            if liveStackView.isHidden {
+                showLiveElements()
+            }
             
         case .noDelay(date: _):
-            hideLiveElements()
+            if !liveStackView.isHidden {
+                hideLiveElements()
+            }
             
         }
         
-        liveLabel.sizeToFit()
-        positionLiveIndicatorView(usingLiveLabel: liveLabel)
+    }
+    
+    private func showLiveElements() {
+        UIView.animate(withDuration: 0.3) {
+            self.liveStackView.isHidden = false
+        }
     }
     
     private func hideLiveElements() {
-        liveIndicatorView.setColor(to: .clear)
-        liveLabel.textColor = .clear
+        UIView.animate(withDuration: 0.3) {
+            self.liveStackView.isHidden = true
+        }
     }
     
     private func setDepartureTime(withStartTime startTime: Date, withDelayState delayState: DelayState) {
@@ -300,137 +447,21 @@ class RouteTableViewCell: UITableViewCell {
             let boardTime = Time.timeString(from: startTime, to: departureTime)
             departureTimeLabel.text = boardTime == "0 min" ? "Board now" : "Board in \(boardTime)"
             
-             departureTimeLabel.textColor = .primaryTextColor
+            departureTimeLabel.textColor = .primaryTextColor
             
         }
         
         arrowImageView.tintColor = .primaryTextColor
-        
-        departureTimeLabel.sizeToFit()
-        positionArrowVertically(usingDepartureTime: departureTimeLabel)
-        positionDepartureTimeHorizontally(usingArrowImageView: arrowImageView)
     }
     
     private func setTravelTime(withDepartureTime departureTime: Date, withArrivalTime arrivalTime: Date){
         travelTimeLabel.text = "\(Time.timeString(from: departureTime)) - \(Time.timeString(from: arrivalTime))"
-        travelTimeLabel.sizeToFit()
     }
     
     private func setDepartureTimeToWalking() {
         departureTimeLabel.text = "Directions"
         departureTimeLabel.textColor = .mediumGrayColor
         arrowImageView.tintColor = .mediumGrayColor
-        
-        departureTimeLabel.sizeToFit()
-        positionArrowVertically(usingDepartureTime: departureTimeLabel)
-    }
-    
-    // MARK: Style
-
-    private func styleTravelTime() {
-        travelTimeLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 16.0)
-        travelTimeLabel.textColor = .primaryTextColor
-        travelTimeLabel.sizeToFit()
-    }
-
-    private func styleLiveElements() {
-        liveLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 14.0)
-        hideLiveElements()
-    }
-
-    private func styleDepartureTime() {
-        departureTimeLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Semibold, size: 14.0)
-        departureTimeLabel.textColor = .primaryTextColor
-        departureTimeLabel.sizeToFit()
-        arrowImageView.tintColor = .primaryTextColor
-    }
-
-    private func styleTopBorder() {
-        topBorder.backgroundColor = .lineDotColor
-    }
-
-    private func styleBottomBorder() {
-        bottomBorder.backgroundColor = .lineDotColor
-    }
-
-    private func styleCellSeperator() {
-        cellSeperator.backgroundColor = .tableBackgroundColor
-    }
-
-    // MARK: Positioning
-
-    func positionSubviews() {
-        positionLiveLabel(usingTravelTime: travelTimeLabel)
-        positionArrowHorizontally()
-        positionDepartureTimeHorizontally(usingArrowImageView: arrowImageView)
-        positionRouteDiagram(usingTravelTimeLabel: travelTimeLabel)
-
-        routeDiagram.positionSubviews()
-
-        styleCellSeperator()
-        styleBottomBorder()
-
-        positionCellSeperator(usingRouteDiagram: routeDiagram)
-        positionBottomBorder(usingCellSeperator: cellSeperator)
-    }
-
-    private func positionTravelTime() {
-        travelTimeLabel.frame = CGRect(x: timeLabelLeftSpaceFromSuperview, y: timeLabelVerticalSpaceFromSuperview, width: 50.5, height: 19)
-    }
-
-    private func positionLiveIndicatorView(usingTravelTime travelTimeLabel: UILabel) {
-        liveIndicatorView.center.x = travelTimeLabel.frame.minX + (liveIndicatorView.frame.width/2)
-        liveIndicatorView.center.y = travelTimeLabel.frame.maxY + liveIndicatorView.frame.height
-    }
-    
-    private func positionLiveIndicatorView(usingLiveLabel liveLabel: UILabel) {
-        liveIndicatorView.center.x =  liveLabel.frame.maxX + liveLabelHorizontalSpaceFromLiveIndicator + (liveIndicatorView.frame.width/2)
-        liveIndicatorView.center.y = liveLabel.frame.maxY - liveIndicatorView.frame.height - 1
-    }
-    
-    private func positionLiveLabel(usingTravelTime travelTimeLabel: UILabel) {
-        liveLabel.frame = CGRect(x: travelTimeLabel.frame.minX, y: travelTimeLabel.frame.maxY, width: liveLabel.frame.width, height: liveLabel.frame.height)
-    }
-
-    private func positionDepartureTimeVertically(usingTravelTime travelTimeLabel: UILabel) {
-        departureTimeLabel.frame = CGRect(x: 0, y: travelTimeLabel.frame.minY, width: 135, height: 20)
-    }
-
-    private func positionArrowVertically(usingDepartureTime departueTimeLabel: UILabel) {
-        arrowImageView.center.y = departureTimeLabel.center.y
-    }
-
-    private func positionTopBorder() {
-        topBorder.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: cellBorderHeight)
-    }
-
-    private func positionArrowHorizontally() {
-        arrowImageView.center.x = contentView.frame.width - arrowImageViewRightSpaceFromSuperview - (arrowImageView.frame.width/2)
-    }
-
-    private func positionDepartureTimeHorizontally(usingArrowImageView arrowImageView: UIImageView) {
-        departureTimeLabel.center.x = arrowImageView.frame.minX - departureLabelSpaceFromArrowImageView - (departureTimeLabel.frame.width/2)
-    }
-
-    private func positionRouteDiagram(usingTravelTimeLabel travelTimeLabel: UILabel) {
-        routeDiagram.frame = CGRect(x: 0, y: travelTimeLabel.frame.maxY + timeLabelAndRouteDiagramVerticalSpace, width: UIScreen.main.bounds.width, height: 75)
-    }
-
-    private func positionCellSeperator(usingRouteDiagram routeDiagram: RouteDiagram) {
-        cellSeperator.frame = CGRect(x: 0, y: contentView.frame.maxY - cellSeparatorHeight, width: UIScreen.main.bounds.width, height: cellSeparatorHeight)
-    }
-
-    private func positionBottomBorder(usingCellSeperator cellSeperator: UIView) {
-        bottomBorder.frame = CGRect(x: 0, y: cellSeperator.frame.minY, width: UIScreen.main.bounds.width, height: cellBorderHeight)
-    }
-
-    // MARK: Add subviews
-
-    func addSubviews() {
-        routeDiagram.addSubviews()
-        contentView.addSubview(routeDiagram)
-        contentView.addSubview(cellSeperator)
-        contentView.addSubview(bottomBorder)
     }
 
 }

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -604,8 +604,8 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
         }
 
         cell?.setData(routes[indexPath.row])
-        cell?.addSubviews()
-        cell?.activateSubviewsConstraints()
+        cell?.addSubviewsToRouteDiagram()
+        cell?.activateRouteDiagramConstraints()
 
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -145,12 +145,12 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
         routeSelection.swapButton.addTarget(self, action: #selector(self.swapFromAndTo), for: .touchUpInside)
     }
 
-    private func setRouteSelectionView(withDestination destination: Place?){
+    private func setRouteSelectionView(withDestination destination: Place?) {
         routeSelection.fromSearchbar.setTitle(Constants.Phrases.fromSearchBarPlaceholder, for: .normal)
         routeSelection.toSearchbar.setTitle(destination?.name ?? "", for: .normal)
     }
 
-    @objc func swapFromAndTo(sender: UIButton){
+    @objc func swapFromAndTo(sender: UIButton) {
         //Swap data
         let searchFromOld = searchFrom
         searchFrom = searchTo

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -604,7 +604,7 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
         }
 
         cell?.setData(routes[indexPath.row])
-        cell?.addSubviewsToRouteDiagram()
+        cell?.addRouteDiagramSubviews()
         cell?.activateRouteDiagramConstraints()
 
         // Add share action for long press gestures on non 3D Touch devices
@@ -734,7 +734,6 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
     // MARK: Tableview Delegate
 
     private func setupRouteResultsTableView() {
-        
         routeResults = UITableView(frame: CGRect(x: 0, y: routeSelection.frame.maxY, width: view.frame.width, height: view.frame.height - routeSelection.frame.height - (navigationController?.navigationBar.frame.height ?? 0)), style: .plain)
         routeResults.delegate = self
         routeResults.allowsSelection = true
@@ -743,8 +742,11 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
         routeResults.backgroundColor = .tableBackgroundColor
         routeResults.alwaysBounceVertical = true //so table view doesn't scroll over top & bottom
         routeResults.showsVerticalScrollIndicator = false
+        
+        // so can have dynamic height cells
         routeResults.estimatedRowHeight = estimatedRowHeight
         routeResults.rowHeight = UITableViewAutomaticDimension
+        
         refreshControl.isHidden = true
 
         if #available(iOS 10.0, *) {
@@ -774,6 +776,11 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
             
             searchForRoutes()
         }
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let tableViewTopMargin: CGFloat = 12
+        return UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: tableViewTopMargin))
     }
     
     // MARK: RouteDetailViewController

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -50,9 +50,7 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
     var refreshControl = UIRefreshControl()
 
     let navigationBarTitle: String = "Route Options"
-    let routeTableViewCellIdentifier: String = RouteTableViewCell().identifier
     let routeResultsTitle: String = "Route Results"
-    let routeResultsHeaderHeight: CGFloat = 57.0
 
     // MARK:  Data vars
 
@@ -66,6 +64,10 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
 
     var isBannerShown: Bool = false
     var cellUserInteraction: Bool = true
+    
+    // MARK: Spacing vars
+    
+    let estimatedRowHeight: CGFloat = 115
 
     // MARK: View Lifecycle
 
@@ -108,7 +110,7 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        routeResults.register(RouteTableViewCell.self, forCellReuseIdentifier: routeTableViewCellIdentifier)
+        routeResults.register(RouteTableViewCell.self, forCellReuseIdentifier: RouteTableViewCell.identifier)
         setupReachability()
     }
 
@@ -595,15 +597,15 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        var cell = tableView.dequeueReusableCell(withIdentifier: routeTableViewCellIdentifier, for: indexPath) as? RouteTableViewCell
+        var cell = tableView.dequeueReusableCell(withIdentifier: RouteTableViewCell.identifier, for: indexPath) as? RouteTableViewCell
 
         if cell == nil {
-            cell = RouteTableViewCell(style: UITableViewCellStyle.default, reuseIdentifier: routeTableViewCellIdentifier)
+            cell = RouteTableViewCell(style: UITableViewCellStyle.default, reuseIdentifier: RouteTableViewCell.identifier)
         }
 
         cell?.setData(routes[indexPath.row])
-        cell?.positionSubviews()
         cell?.addSubviews()
+        cell?.activateSubviewsConstraints()
 
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))
@@ -733,7 +735,7 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
 
     private func setupRouteResultsTableView() {
         
-        routeResults = UITableView(frame: CGRect(x: 0, y: routeSelection.frame.maxY, width: view.frame.width, height: view.frame.height - routeSelection.frame.height - (navigationController?.navigationBar.frame.height ?? 0)), style: .grouped)
+        routeResults = UITableView(frame: CGRect(x: 0, y: routeSelection.frame.maxY, width: view.frame.width, height: view.frame.height - routeSelection.frame.height - (navigationController?.navigationBar.frame.height ?? 0)), style: .plain)
         routeResults.delegate = self
         routeResults.allowsSelection = true
         routeResults.dataSource = self
@@ -741,7 +743,8 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
         routeResults.backgroundColor = .tableBackgroundColor
         routeResults.alwaysBounceVertical = true //so table view doesn't scroll over top & bottom
         routeResults.showsVerticalScrollIndicator = false
-
+        routeResults.estimatedRowHeight = estimatedRowHeight
+        routeResults.rowHeight = UITableViewAutomaticDimension
         refreshControl.isHidden = true
 
         if #available(iOS 10.0, *) {
@@ -749,17 +752,6 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
         } else {
             routeResults.addSubview(refreshControl)
         }
-    }
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        let directions = routes[indexPath.row].rawDirections
-        let isWalkingRoute = routes[indexPath.row].isRawWalkingRoute()
-
-        // if walking route, don't skip first walking direction. Ow skip first walking direction
-        let numOfStops = isWalkingRoute ? directions.count : (directions.first?.type == .walk ? directions.count - 1 : directions.count)
-        let rowHeight = RouteTableViewCell().heightForCell(withNumOfStops: numOfStops, withNumOfWalkLines: routes[indexPath.row].getRawNumOfWalkLines())
-
-        return rowHeight
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/TCAT/Model/BusStop.swift
+++ b/TCAT/Model/BusStop.swift
@@ -24,7 +24,7 @@ class BusStop: Place, CoordinateAcceptor {
     }
     
     override func isEqual(_ object: Any?) -> Bool {
-        if (!super.isEqual(object)){
+        if (!super.isEqual(object)) {
             return false
         }
         

--- a/TCAT/Model/PlaceResult.swift
+++ b/TCAT/Model/PlaceResult.swift
@@ -35,7 +35,7 @@ class PlaceResult: Place, JSONDecodable, CoordinateAcceptor {
     }
     
     override func isEqual(_ object: Any?) -> Bool {
-        if (!super.isEqual(object)){
+        if (!super.isEqual(object)) {
             return false
         }
         

--- a/TCAT/Utilities/Extensions.swift
+++ b/TCAT/Utilities/Extensions.swift
@@ -322,7 +322,7 @@ extension Double {
 
 extension Array where Element: UIView {
     /// Remove each view from its superview.
-    func removeViewsFromSuperview(){
+    func removeViewsFromSuperview() {
         self.forEach { $0.removeFromSuperview() }
     }
 }

--- a/TCAT/Utilities/Loader.swift
+++ b/TCAT/Utilities/Loader.swift
@@ -53,7 +53,7 @@ extension UIColor {
 
 extension UIView{
     
-    func boundInside(_ superView: UIView){
+    func boundInside(_ superView: UIView) {
         
         self.translatesAutoresizingMaskIntoConstraints = false
         superView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[subview]-0-|", options: NSLayoutFormatOptions(), metrics:nil, views:["subview":self]))

--- a/TCAT/Utilities/SearchTableViewHelpers.swift
+++ b/TCAT/Utilities/SearchTableViewHelpers.swift
@@ -57,7 +57,7 @@ class SearchTableViewManager {
     static let shared = SearchTableViewManager()
     private var allStops: [BusStop]?
 
-    private init(){}
+    private init() {}
     func getAllStops() -> [BusStop] {
         if let stops = allStops {
             return stops

--- a/TCAT/Views/BusIcon.swift
+++ b/TCAT/Views/BusIcon.swift
@@ -10,6 +10,7 @@ import UIKit
 enum BusIconType: String {
     case directionSmall, directionLarge, liveTracking
     
+    /// Return BusIcon's frame width
     var width: CGFloat {
         switch self {
         case .directionSmall:
@@ -21,6 +22,7 @@ enum BusIconType: String {
         }
     }
     
+    /// Return BusIcon's frame height
     var height: CGFloat {
         switch self {
         case .directionSmall:
@@ -32,6 +34,7 @@ enum BusIconType: String {
         }
     }
     
+    /// Return BusIcon's corner radius
     var cornerRadius: CGFloat {
         switch self {
         case .directionLarge:

--- a/TCAT/Views/BusIcon.swift
+++ b/TCAT/Views/BusIcon.swift
@@ -8,34 +8,73 @@
 import UIKit
 
 enum BusIconType: String {
-    case directionSmall
-    case directionLarge
-    case liveTracking
+    case directionSmall, directionLarge, liveTracking
+    
+    var width: CGFloat {
+        switch self {
+        case .directionSmall:
+            return 48
+        case .liveTracking:
+            return 72
+        case .directionLarge:
+            return 72
+        }
+    }
+    
+    var height: CGFloat {
+        switch self {
+        case .directionSmall:
+            return 24
+        case .liveTracking:
+            return 30
+        case .directionLarge:
+            return 36
+        }
+    }
+    
+    var cornerRadius: CGFloat {
+        switch self {
+        case .directionLarge:
+            return 8
+        default:
+            return 4
+        }
+    }
 }
 
 class BusIcon: UIView {
     
-    var number: Int = 99
+    // MARK: Data vars
+    
+    let type: BusIconType
+    let number: Int
+    
+    // MARK: View vars
     
     var baseView: UIView!
     var label: UILabel!
     var image: UIImageView!
     var liveIndicator: LiveIndicator?
     
+    // MARK: Constraint vars
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: type.width, height: type.height)
+    }
+    
+    // MARK: Init
+    
     init(type: BusIconType, number: Int) {
-        
-        switch type {
-            case .directionSmall: super.init(frame: CGRect(x: 0, y: 0, width: 48, height: 24))
-            case .liveTracking : super.init(frame: CGRect(x: 0, y: 0, width: 72, height: 30))
-            case .directionLarge : super.init(frame: CGRect(x: 0, y: 0, width: 72, height: 36))
-        }
-        
+        self.type = type
         self.number = number
+
+        super.init(frame: CGRect(x: 0, y: 0, width: type.width, height: type.height))
+        
         self.backgroundColor = .clear
         
         baseView = UIView(frame: self.frame)
         baseView.backgroundColor = .tcatBlueColor
-        baseView.layer.cornerRadius = type == .directionLarge ? 8 : 4
+        baseView.layer.cornerRadius = type.cornerRadius
         addSubview(baseView)
         
         image = UIImageView(image: UIImage(named: "bus"))
@@ -75,15 +114,19 @@ class BusIcon: UIView {
         
     }
     
+    required init?(coder aDecoder: NSCoder) {
+        type = .directionSmall
+        number = 99
+        super.init(coder: aDecoder)
+    }
+    
+    // MARK: Reuse
+    
     func prepareForReuse() {
         baseView.removeFromSuperview()
         label.removeFromSuperview()
         image.removeFromSuperview()
         liveIndicator?.removeFromSuperview()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
     }
     
 }

--- a/TCAT/Views/Circle.swift
+++ b/TCAT/Views/Circle.swift
@@ -24,9 +24,20 @@ enum CircleSize: Int {
 
 class Circle: UIView {
     
+    // MARK: Data vars
+    
+    let diameter: CGFloat
+    
+    // MARK: Constraint vars
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: diameter, height: diameter)
+    }
+    
+    // MARK: Init
+    
     init(size: CircleSize, style: CircleStyle, color: UIColor) {
-        
-        let diameter: CGFloat = CGFloat(size.rawValue)
+        diameter = CGFloat(size.rawValue)
         super.init(frame: CGRect(x: 0, y: 0, width: diameter, height: diameter))
         
         layer.cornerRadius = frame.width / 2
@@ -63,6 +74,7 @@ class Circle: UIView {
     }
     
     required init?(coder aDecoder: NSCoder) {
+        diameter = CGFloat(CircleSize.small.rawValue)
         super.init(coder: aDecoder)
     }
     

--- a/TCAT/Views/DatePickerView.swift
+++ b/TCAT/Views/DatePickerView.swift
@@ -46,7 +46,7 @@ class DatePickerView: UIView {
 
     // MARK: Init
 
-    override init(frame: CGRect){
+    override init(frame: CGRect) {
         leaveNowSegmentedControlOptions = [typeToSegmentControlElements[.leaveNow]!.title]
         timeTypeSegmentedControlOptions = [typeToSegmentControlElements[.leaveAt]!.title, typeToSegmentControlElements[.arriveBy]!.title]
         
@@ -122,23 +122,23 @@ class DatePickerView: UIView {
 
     // MARK: Style
 
-    private func styleDatepicker(){
+    private func styleDatepicker() {
         datepicker.frame = CGRect(x: 0, y: 0, width: self.frame.width, height: datePickerHeight)
     }
 
-    private func styleSegmentedControl(_ segmentedControl: UISegmentedControl){
+    private func styleSegmentedControl(_ segmentedControl: UISegmentedControl) {
         segmentedControl.tintColor = .tcatBlueColor
         let segmentControlFont = UIFont(name: Constants.Fonts.SanFrancisco.Regular, size: 13.0)
         segmentedControl.setTitleTextAttributes([NSAttributedStringKey.font: segmentControlFont!], for: .normal)
     }
 
-    private func styleCancelButton(){
+    private func styleCancelButton() {
         cancelButton.frame = CGRect(x: 0, y: 0, width: 60, height: buttonHeight)
         cancelButton.titleLabel?.font = UIFont(name: Constants.Fonts.SanFrancisco.Regular, size: 17.0)
         cancelButton.setTitleColor(.mediumGrayColor, for: .normal)
     }
 
-    private func styleDoneButton(){
+    private func styleDoneButton() {
         doneButton.frame = CGRect(x: 0, y: 0, width: 55, height: buttonHeight)
         doneButton.titleLabel?.font = UIFont(name: Constants.Fonts.SanFrancisco.Regular, size: 17.0)
         doneButton.setTitleColor(.tcatBlueColor, for: .normal)
@@ -146,7 +146,7 @@ class DatePickerView: UIView {
 
     // MARK: Set data
 
-    private func setDatepickerSettings(){
+    private func setDatepickerSettings() {
         let now = Date()
         datepicker.minimumDate = now
 
@@ -156,23 +156,23 @@ class DatePickerView: UIView {
         datepicker.addTarget(self, action: #selector(datepickerValueChanged(datepicker:)), for: .valueChanged)
     }
 
-    private func setSegmentedControl(_ segmentedContol: UISegmentedControl, withItems titles: [String]){
+    private func setSegmentedControl(_ segmentedContol: UISegmentedControl, withItems titles: [String]) {
         for i in titles.indices {
             segmentedContol.insertSegment(withTitle: titles[i], at: i, animated: false)
         }
     }
 
-    private func setCancelButton(withTitle title: String){
+    private func setCancelButton(withTitle title: String) {
         cancelButton.setTitle(title, for: .normal)
     }
 
-    private func setDoneButton(withTitle title: String){
+    private func setDoneButton(withTitle title: String) {
         doneButton.setTitle(title, for: .normal)
     }
 
     // MARK: Position
 
-    func positionSubviews(){
+    func positionSubviews() {
         positionCancelButton()
         positionDoneButton()
         positionTimeTypeSegmentedControl(usingCancelButton: cancelButton)
@@ -180,21 +180,21 @@ class DatePickerView: UIView {
         positionDatepicker(usingSegmentedControl: timeTypeSegmentedControl)
      }
 
-    private func positionCancelButton(){
+    private func positionCancelButton() {
         let oldFrame = cancelButton.frame
         let newFrame = CGRect(x: spaceBtButtonAndSuperviewSide, y: spaceBtButtonAndSuprviewTop, width: oldFrame.width, height: oldFrame.height)
 
         cancelButton.frame = newFrame
     }
 
-    private func positionDoneButton(){
+    private func positionDoneButton() {
         let oldFrame = doneButton.frame
         let newFrame = CGRect(x: self.frame.width - spaceBtButtonAndSuperviewSide - oldFrame.width, y: spaceBtButtonAndSuprviewTop, width: oldFrame.width, height: oldFrame.height)
 
         doneButton.frame = newFrame
     }
 
-    private func positionTimeTypeSegmentedControl(usingCancelButton cancelButton: UIButton){
+    private func positionTimeTypeSegmentedControl(usingCancelButton cancelButton: UIButton) {
         timeTypeSegmentedControl.frame = CGRect(x: 0, y: cancelButton.frame.maxY + spaceBtButtonAndSegmentedControl, width: (self.frame.width*(343/375) - spaceBtSegmentControls)*(2/3), height: segmentedControlHeight)
 
         timeTypeSegmentedControl.center.x = self.frame.width/2 + timeTypeSegmentedControl.frame.width/4 + spaceBtSegmentControls/2
@@ -205,7 +205,7 @@ class DatePickerView: UIView {
         leaveNowSegmentedControl.frame = CGRect(x: timeTypeSegmentedControl.frame.minX - spaceBtSegmentControls - width, y: timeTypeSegmentedControl.frame.minY, width: width, height: segmentedControlHeight)
     }
 
-    private func positionDatepicker(usingSegmentedControl segmentedControl: UISegmentedControl){
+    private func positionDatepicker(usingSegmentedControl segmentedControl: UISegmentedControl) {
         let oldFrame = datepicker.frame
         let newFrame = CGRect(x: 0, y: segmentedControl.frame.maxY + spaceBtSegmentControlAndDatePicker, width: oldFrame.width, height: oldFrame.height)
 
@@ -216,7 +216,7 @@ class DatePickerView: UIView {
 
     // MARK:  Add subviews
 
-    func addSubviews(){
+    func addSubviews() {
         addSubview(cancelButton)
         addSubview(doneButton)
         addSubview(timeTypeSegmentedControl)

--- a/TCAT/Views/LiveIndicator.swift
+++ b/TCAT/Views/LiveIndicator.swift
@@ -39,7 +39,7 @@ class LiveIndicator: UIView {
     init(size: LiveIndicatorSize, color: UIColor) {
         super.init(frame: CGRect(x: 0, y: 0, width: size.rawValue, height: size.rawValue))
         
-        let lineWidth = frame.width/4
+        let lineWidth = bounds.width/4
         
         circleLayer = getCircleLayer(color: color)
         largeArcLayer = getLargeArcLayer(color: color, lineWidth:  lineWidth)
@@ -70,7 +70,7 @@ class LiveIndicator: UIView {
     // MARK: Create views
     
     private func getCircleLayer(color: UIColor) -> CAShapeLayer {
-        let circlePath = UIBezierPath(ovalIn: CGRect(x: 0.0, y: frame.maxY - frame.size.height/4, width: frame.size.width/4, height: frame.size.height/4))
+        let circlePath = UIBezierPath(ovalIn: CGRect(x: 0.0, y: bounds.maxY - bounds.size.height/4, width: bounds.size.width/4, height: bounds.size.height/4))
         
         let circleLayer = CAShapeLayer()
         circleLayer.path = circlePath.cgPath
@@ -80,9 +80,9 @@ class LiveIndicator: UIView {
     }
     
     private func getLargeArcLayer(color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
-        let radius = frame.size.height + lineWidth/2
+        let radius = bounds.size.height + lineWidth/2
         
-        let largeArcpath = UIBezierPath(arcCenter: CGPoint(x: 0, y: frame.maxY),
+        let largeArcpath = UIBezierPath(arcCenter: CGPoint(x: 0, y: bounds.maxY),
                                         radius: radius,
                                         startAngle:  .pi * (3 / 2) + asin((lineWidth/2) / (radius + (lineWidth/2))),
                                         endAngle: -asin((lineWidth/2) / (radius + (lineWidth/2))),
@@ -91,16 +91,16 @@ class LiveIndicator: UIView {
         largeArcLayer.path = largeArcpath.cgPath
         largeArcLayer.strokeColor = color.cgColor
         largeArcLayer.fillColor = UIColor.clear.cgColor
-        largeArcLayer.lineWidth = frame.width/4
+        largeArcLayer.lineWidth = bounds.width/4
         largeArcLayer.lineCap = kCALineCapRound
         
         return largeArcLayer
     }
     
     private func getSmallArcLayer(color: UIColor, lineWidth: CGFloat) -> CAShapeLayer {
-        let radius = frame.size.height/2 + lineWidth/2
+        let radius = bounds.size.height/2 + lineWidth/2
         
-        let smallArcpath = UIBezierPath(arcCenter: CGPoint(x: 0, y: frame.maxY),
+        let smallArcpath = UIBezierPath(arcCenter: CGPoint(x: 0, y: bounds.maxY),
                                         radius: radius,
                                         startAngle:  .pi * (3 / 2) + asin((lineWidth/2) / (radius + (lineWidth/2))),
                                         endAngle: -asin((lineWidth/2) / (radius + (lineWidth/2))),
@@ -109,7 +109,7 @@ class LiveIndicator: UIView {
         smallArcLayer.path = smallArcpath.cgPath
         smallArcLayer.strokeColor = color.cgColor
         smallArcLayer.fillColor = UIColor.clear.cgColor
-        smallArcLayer.lineWidth = frame.width/4
+        smallArcLayer.lineWidth = bounds.width/4
         smallArcLayer.lineCap = kCALineCapRound
         
         return smallArcLayer

--- a/TCAT/Views/LiveIndicator.swift
+++ b/TCAT/Views/LiveIndicator.swift
@@ -14,6 +14,11 @@ enum LiveIndicatorSize: Double {
 
 class LiveIndicator: UIView {
     
+    // MARK: State vars
+    
+    let size: LiveIndicatorSize
+    let lineWidth: CGFloat
+    
     // MARK: View vars
     
     var circleLayer: CAShapeLayer!
@@ -23,7 +28,6 @@ class LiveIndicator: UIView {
     // MARK: Animation vars
     
     static let INTERVAL: TimeInterval = 4.0
-    
     static let DURATION: TimeInterval = 0.2
     let START_DELAY: TimeInterval = 0.0
     let END_DELAY: TimeInterval = 0.0 // 0.25
@@ -33,13 +37,16 @@ class LiveIndicator: UIView {
     // MARK: Init
     
     required init?(coder aDecoder: NSCoder) {
+        size = .small
+        lineWidth = CGFloat(size.rawValue)/4
         super.init(coder: aDecoder)
     }
     
     init(size: LiveIndicatorSize, color: UIColor) {
+        self.size = size
+        self.lineWidth = CGFloat(size.rawValue)/4
+
         super.init(frame: CGRect(x: 0, y: 0, width: size.rawValue, height: size.rawValue))
-        
-        let lineWidth = bounds.width/4
         
         circleLayer = getCircleLayer(color: color)
         largeArcLayer = getLargeArcLayer(color: color, lineWidth:  lineWidth)
@@ -55,6 +62,10 @@ class LiveIndicator: UIView {
     }
     
     // MARK: Resize
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: CGFloat(size.rawValue) + lineWidth, height: CGFloat(size.rawValue) + lineWidth)
+    }
     
     private func resizeFrameToFitLayers(lineWidth: CGFloat) {
         frame = CGRect(x: frame.minX, y: frame.minY, width: frame.width + lineWidth, height: frame.height + lineWidth)

--- a/TCAT/Views/LiveIndicator.swift
+++ b/TCAT/Views/LiveIndicator.swift
@@ -32,7 +32,12 @@ class LiveIndicator: UIView {
     let START_DELAY: TimeInterval = 0.0
     let END_DELAY: TimeInterval = 0.0 // 0.25
     let DIM_OPACITY: CGFloat = 0.5
-    let INTERVAL: TimeInterval = LiveIndicator.INTERVAL
+    
+    // MARK: Constraint vars
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: CGFloat(size.rawValue) + lineWidth, height: CGFloat(size.rawValue) + lineWidth)
+    }
     
     // MARK: Init
     
@@ -62,10 +67,6 @@ class LiveIndicator: UIView {
     }
     
     // MARK: Resize
-    
-    override var intrinsicContentSize: CGSize {
-        return CGSize(width: CGFloat(size.rawValue) + lineWidth, height: CGFloat(size.rawValue) + lineWidth)
-    }
     
     private func resizeFrameToFitLayers(lineWidth: CGFloat) {
         frame = CGRect(x: frame.minX, y: frame.minY, width: frame.width + lineWidth, height: frame.height + lineWidth)
@@ -140,7 +141,7 @@ class LiveIndicator: UIView {
         var timeInterval: TimeInterval = 0
         
         for layer in [circleLayer, smallArcLayer, largeArcLayer] {
-            let timer = Timer(fireAt: Date().addingTimeInterval(timeInterval), interval: INTERVAL, target: self,
+            let timer = Timer(fireAt: Date().addingTimeInterval(timeInterval), interval: LiveIndicator.INTERVAL, target: self,
                               selector: #selector(self.animateLayer), userInfo: layer, repeats: true)
             RunLoop.main.add(timer, forMode: .commonModes)
             timeInterval += LiveIndicator.DURATION

--- a/TCAT/Views/RouteDiagram.swift
+++ b/TCAT/Views/RouteDiagram.swift
@@ -33,12 +33,17 @@ class RouteDiagram: UIView {
     var routeDiagramElements: [RouteDiagramElement] = []
 
     // MARK: Spacing vars
-
-    let stopDotLeftSpaceFromSuperview: CGFloat = 77.0
-    let busIconLeftSpaceFromSuperview: CGFloat = 16.0
-    let walkIconAndRouteLineHorizontalSpace: CGFloat = 36.0
-    let stopDotAndStopLabelHorizontalSpace: CGFloat = 14.0
-    let stopLabelAndDistLabelHorizontalSpace: CGFloat = 8
+    let topMargin: CGFloat = 16
+    let spaceBtnStopDotAndStopLabel: CGFloat = 14
+    
+    let spaceBtnBusIconAndRouteLine: CGFloat = 19.5
+    let spaceBtnWalkIconAndRouteLine: CGFloat = 38
+    let spaceBtnWalkWithDistanceIconAndRouteLine: CGFloat = 24
+    
+    let spaceBtnWalkIconAndSuperview: CGFloat = 20
+    
+    let busIconType: BusIconType = .directionSmall
+    let busIconCornerRadius: CGFloat = BusIconType.directionSmall.cornerRadius
 
     // MARK: Init
 
@@ -228,7 +233,7 @@ class RouteDiagram: UIView {
 
             case .depart:
                 let busNum = directions[index].routeNumber
-                let busIcon = BusIcon(type: .directionSmall, number: busNum)
+                let busIcon = BusIcon(type: busIconType, number: busNum)
                 return busIcon
 
             default:
@@ -292,37 +297,14 @@ class RouteDiagram: UIView {
             let stopDot = first.stopDot
             let stopLabel = first.stopLabel
             
-            let topMargin: CGFloat = 16
-            let spaceBtnStopDotAndStopLabel: CGFloat = 14
-            
-            NSLayoutConstraint.activate([
-                stopLabel.topAnchor.constraint(equalTo: topAnchor, constant: topMargin),
-                stopLabel.leadingAnchor.constraint(equalTo: stopDot.trailingAnchor, constant: spaceBtnStopDotAndStopLabel),
-                
-                stopDot.topAnchor.constraint(equalTo: stopLabel.topAnchor),
-            ])
+            activateFirst(stopDot, stopLabel)
             
             if let routeLine = first.routeLine {
-                NSLayoutConstraint.activate([
-                    routeLine.centerXAnchor.constraint(equalTo: stopDot.centerXAnchor),
-                    routeLine.topAnchor.constraint(equalTo: stopDot.bottomAnchor),
-                ])
+                activateFirst(routeLine, with: stopDot)
             }
             
-            let spaceBtnBusIconAndRouteLine: CGFloat = 19.5
-            let spaceBtnWalkIconAndRouteLine: CGFloat = 38
-            let spaceBtnWalkWithDistanceIconAndRouteLine: CGFloat = 24
-            
-            let spaceBtnWalkIconAndSuperview: CGFloat = 20
-            
             if let icon = first.icon, let routeLine = first.routeLine {
-                let spaceBtnIconAndRouteLine = icon is UIImageView ? spaceBtnWalkIconAndRouteLine : (icon is WalkWithDistanceIcon ? spaceBtnWalkWithDistanceIconAndRouteLine : spaceBtnBusIconAndRouteLine)
-                let spaceBtnIconAndSuperview = icon is UIImageView ? spaceBtnWalkIconAndSuperview : 0
-                NSLayoutConstraint.activate([
-                    icon.centerYAnchor.constraint(equalTo: routeLine.centerYAnchor),
-                    icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: spaceBtnIconAndSuperview),
-                    icon.trailingAnchor.constraint(equalTo: routeLine.leadingAnchor, constant: -spaceBtnIconAndRouteLine)
-                ])
+                activateFirst(icon, with: routeLine)
             }
         }
         
@@ -337,60 +319,109 @@ class RouteDiagram: UIView {
             let stopDot = current.stopDot
             
             if let prevRouteLine = prev.routeLine {
-                NSLayoutConstraint.activate([
-                    stopDot.topAnchor.constraint(equalTo: prevRouteLine.bottomAnchor),
-                    stopDot.centerXAnchor.constraint(equalTo: prevRouteLine.centerXAnchor)
-                    ])
+                activate(stopDot, with: prevRouteLine)
             }
             
             let stopLabel = current.stopLabel
             
-            NSLayoutConstraint.activate([
-                stopLabel.leadingAnchor.constraint(equalTo: prev.stopLabel.leadingAnchor),
-                stopLabel.topAnchor.constraint(equalTo: stopDot.topAnchor)
-            ])
+            activate(stopLabel, with: stopDot, with: prev.stopLabel)
             
             if let routeLine = current.routeLine {
-                NSLayoutConstraint.activate([
-                    routeLine.topAnchor.constraint(equalTo: stopDot.bottomAnchor),
-                    routeLine.centerXAnchor.constraint(equalTo: stopDot.centerXAnchor)
-                ])
+                activate(routeLine, with: stopDot)
             }
             
             if let icon = current.icon, let routeLine = current.routeLine {
-                NSLayoutConstraint.activate([
-                    icon.centerYAnchor.constraint(equalTo: routeLine.centerYAnchor)
-                ])
-                
-                if let prevIcon = prev.icon {
-                    NSLayoutConstraint.activate([
-                        icon.centerXAnchor.constraint(equalTo: prevIcon.centerXAnchor)
-                    ])
-                }
+                activate(icon, with: routeLine, with: prev)
             }
             
             if let stayOnBusCoverUpView = current.stayOnBusCoverUpView, let icon = current.icon {
-                let busIconCornerRadius = BusIconType.directionSmall.cornerRadius
-                
-                NSLayoutConstraint.activate([
-                    stayOnBusCoverUpView.centerXAnchor.constraint(equalTo: icon.centerXAnchor),
-                    stayOnBusCoverUpView.bottomAnchor.constraint(equalTo: icon.topAnchor, constant: busIconCornerRadius),
-                    stayOnBusCoverUpView.widthAnchor.constraint(equalToConstant: icon.intrinsicContentSize.width),
-                ])
-                
-                if let prevIcon = prev.icon {
-                    NSLayoutConstraint.activate([
-                        stayOnBusCoverUpView.topAnchor.constraint(equalTo: prevIcon.bottomAnchor, constant: -busIconCornerRadius),
-                    ])
-                }
+                activate(stayOnBusCoverUpView, with: icon, with: prev)
             }
         }
         
-        if let lastStopLabel = routeDiagramElements.last?.stopLabel {
-            NSLayoutConstraint.activate([
-                lastStopLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
-            ])
+        if let stopLabel = routeDiagramElements.last?.stopLabel {
+            activateLast(stopLabel)
         }
+    }
+    
+    private func activateFirst(_ stopDot: Circle, _ stopLabel: UILabel) {
+        NSLayoutConstraint.activate([
+            stopLabel.topAnchor.constraint(equalTo: topAnchor, constant: topMargin),
+            stopLabel.leadingAnchor.constraint(equalTo: stopDot.trailingAnchor, constant: spaceBtnStopDotAndStopLabel),
+            
+            stopDot.topAnchor.constraint(equalTo: stopLabel.topAnchor),
+        ])
+    }
+    
+    private func activateFirst(_ routeLine: RouteLine, with stopDot: Circle) {
+        NSLayoutConstraint.activate([
+            routeLine.centerXAnchor.constraint(equalTo: stopDot.centerXAnchor),
+            routeLine.topAnchor.constraint(equalTo: stopDot.bottomAnchor),
+        ])
+    }
+    
+    private func activateFirst(_ icon: UIView, with routeLine: RouteLine) {
+        let spaceBtnIconAndRouteLine = icon is UIImageView ? spaceBtnWalkIconAndRouteLine : (icon is WalkWithDistanceIcon ? spaceBtnWalkWithDistanceIconAndRouteLine : spaceBtnBusIconAndRouteLine)
+        let spaceBtnIconAndSuperview = icon is UIImageView ? spaceBtnWalkIconAndSuperview : 0
+        
+        NSLayoutConstraint.activate([
+            icon.centerYAnchor.constraint(equalTo: routeLine.centerYAnchor),
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: spaceBtnIconAndSuperview),
+            icon.trailingAnchor.constraint(equalTo: routeLine.leadingAnchor, constant: -spaceBtnIconAndRouteLine)
+        ])
+    }
+    
+    private func activate(_ stopDot: Circle, with prevRouteLine: RouteLine) {
+        NSLayoutConstraint.activate([
+            stopDot.topAnchor.constraint(equalTo: prevRouteLine.bottomAnchor),
+            stopDot.centerXAnchor.constraint(equalTo: prevRouteLine.centerXAnchor)
+        ])
+    }
+    
+    private func activate(_ stopLabel: UILabel, with stopDot: Circle, with prevStopLabel: UILabel) {
+        NSLayoutConstraint.activate([
+            stopLabel.leadingAnchor.constraint(equalTo: prevStopLabel.leadingAnchor),
+            stopLabel.topAnchor.constraint(equalTo: stopDot.topAnchor)
+        ])
+    }
+    
+    private func activate(_ routeLine: RouteLine, with stopDot: Circle) {
+        NSLayoutConstraint.activate([
+            routeLine.topAnchor.constraint(equalTo: stopDot.bottomAnchor),
+            routeLine.centerXAnchor.constraint(equalTo: stopDot.centerXAnchor)
+        ])
+    }
+    
+    private func activate(_ icon: UIView, with routeLine: RouteLine, with prev: RouteDiagramElement) {
+        NSLayoutConstraint.activate([
+            icon.centerYAnchor.constraint(equalTo: routeLine.centerYAnchor)
+            ])
+        
+        if let prevIcon = prev.icon {
+            NSLayoutConstraint.activate([
+                icon.centerXAnchor.constraint(equalTo: prevIcon.centerXAnchor)
+                ])
+        }
+    }
+    
+    private func activate(_ stayOnBusCoverUpView: UIView, with icon: UIView, with prev: RouteDiagramElement) {
+        NSLayoutConstraint.activate([
+            stayOnBusCoverUpView.centerXAnchor.constraint(equalTo: icon.centerXAnchor),
+            stayOnBusCoverUpView.bottomAnchor.constraint(equalTo: icon.topAnchor, constant: busIconCornerRadius),
+            stayOnBusCoverUpView.widthAnchor.constraint(equalToConstant: icon.intrinsicContentSize.width),
+            ])
+        
+        if let prevIcon = prev.icon {
+            NSLayoutConstraint.activate([
+                stayOnBusCoverUpView.topAnchor.constraint(equalTo: prevIcon.bottomAnchor, constant: -busIconCornerRadius),
+                ])
+        }
+    }
+    
+    private func activateLast(_ stopLabel: UILabel) {
+        NSLayoutConstraint.activate([
+            stopLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
     }
     
     private func setTranslatesAutoresizingMaskIntoConstraints() {

--- a/TCAT/Views/RouteLine.swift
+++ b/TCAT/Views/RouteLine.swift
@@ -10,13 +10,28 @@ import UIKit
 
 class RouteLine: UIView {
     
-    let width: CGFloat = 4.0
+    // MARK: Size vars
     
-    init(x: CGFloat, y: CGFloat, height: CGFloat){
-        
-        let frame = CGRect(x: x, y: y, width: width, height: height)
-        
-        super.init(frame: frame)
+    let width: CGFloat = 4
+    var height: CGFloat = 20
+    
+    static let extendedHeight: CGFloat = 28
+    
+    // MARK: Constraint vars
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: width, height: height)
+    }
+    
+    // MARK: Init
+    
+    init(x: CGFloat, y: CGFloat, height: CGFloat) {
+        self.height = height
+        super.init(frame: CGRect(x: x, y: y, width: width, height: height))
+    }
+    
+    init(x: CGFloat, y: CGFloat) {
+        super.init(frame: CGRect(x: x, y: y, width: width, height: height))
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -26,9 +41,17 @@ class RouteLine: UIView {
 }
 
 class SolidLine: RouteLine {
-    
+
+    // MARK: Init
+
     init(x: CGFloat, y: CGFloat, height: CGFloat, color: UIColor) {
         super.init(x: x, y: y, height: height)
+        
+        backgroundColor = color
+    }
+    
+    init(color: UIColor) {
+        super.init(x: 0, y: 0)
         
         backgroundColor = color
     }
@@ -36,6 +59,7 @@ class SolidLine: RouteLine {
     convenience init(height: CGFloat, color: UIColor) {
         self.init(x: 0, y: 0, height: height, color: color)
     }
+    
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -45,8 +69,29 @@ class SolidLine: RouteLine {
 
 class DottedLine: RouteLine {
     
+    // MARK: Init
+    
     init(x: CGFloat, y: CGFloat, height: CGFloat, color: UIColor){
         super.init(x: x, y: y, height: height)
+        
+        let dashHeight: CGFloat = 3.75
+        let dashSpace: CGFloat = 4
+        
+        var nextDashYPos: CGFloat = dashSpace
+        while nextDashYPos <= height - dashHeight {
+            let line = CALayer()
+            
+            line.frame = CGRect(x: 0, y: nextDashYPos, width: frame.width, height: dashHeight)
+            line.backgroundColor = color.cgColor
+            line.cornerRadius = dashHeight / 2
+            
+            layer.addSublayer(line)
+            nextDashYPos += line.frame.height + dashSpace
+        }
+    }
+    
+    init(color: UIColor) {
+        super.init(x: 0, y: 0)
         
         let dashHeight: CGFloat = 3.75
         let dashSpace: CGFloat = 4
@@ -63,6 +108,7 @@ class DottedLine: RouteLine {
             nextDashYPos += line.frame.height + dashSpace
         }
     }
+        
         
     convenience init(height: CGFloat, color: UIColor) {
         self.init(x: 0, y: 0, height: height, color: color)

--- a/TCAT/Views/RouteLine.swift
+++ b/TCAT/Views/RouteLine.swift
@@ -71,7 +71,7 @@ class DottedLine: RouteLine {
     
     // MARK: Init
     
-    init(x: CGFloat, y: CGFloat, height: CGFloat, color: UIColor){
+    init(x: CGFloat, y: CGFloat, height: CGFloat, color: UIColor) {
         super.init(x: x, y: y, height: height)
         
         let dashHeight: CGFloat = 3.75

--- a/TCAT/Views/RouteSelectionView.swift
+++ b/TCAT/Views/RouteSelectionView.swift
@@ -126,17 +126,17 @@ class RouteSelectionView: UIView {
         
     // MARK: Set data
     
-    private func setLabel(_ label: UILabel, withText text: String){
+    private func setLabel(_ label: UILabel, withText text: String) {
         label.text = text
         label.sizeToFit()
     }
     
-    private func setSwapButton(withImage image: UIImage){
+    private func setSwapButton(withImage image: UIImage) {
         swapButton.setImage(image, for: .normal)
         swapButton.tintColor = .mediumGrayColor
     }
     
-    private func setDatpickerButton(withImage image: UIImage){
+    private func setDatpickerButton(withImage image: UIImage) {
         datepickerButton.setImage(image, for: .normal)
     }
     
@@ -158,7 +158,7 @@ class RouteSelectionView: UIView {
     
     // MARK: Position
     
-    func positionSubviews(){
+    func positionSubviews() {
         positionLabelHorizontally(fromLabel)
         positionLabelHorizontally(toLabel)
         postionSolidCircleHorizontally(usingFromLabel: fromLabel)
@@ -184,7 +184,7 @@ class RouteSelectionView: UIView {
         positionSwapButton(usingFromSearchBar: fromSearchbar, usingLine: line)
     }
     
-    private func positionLabelHorizontally(_ label: UILabel){
+    private func positionLabelHorizontally(_ label: UILabel) {
         let oldFrame = label.frame
         let newFrame = CGRect(x: leadingSpace, y: oldFrame.minY, width: oldFrame.width, height: oldFrame.height)
         
@@ -195,21 +195,21 @@ class RouteSelectionView: UIView {
         solidCircle.center.x = fromLabel.frame.maxX + solidCircleLeftSpace + (solidCircle.frame.width/2)
     }
     
-    private func positionFromSearchbar(usingSolidCircle solidCircle: Circle){
+    private func positionFromSearchbar(usingSolidCircle solidCircle: Circle) {
         let oldFrame = fromSearchbar.frame
         let newFrame = CGRect(x: solidCircle.frame.maxX + solidCircleRightSpace, y: topSpace, width: oldFrame.width, height: oldFrame.height)
         
         fromSearchbar.frame = newFrame
     }
     
-    private func positionToSearchbar(usingFromSearchbar fromSearchbar: UIButton){
+    private func positionToSearchbar(usingFromSearchbar fromSearchbar: UIButton) {
         let oldFrame = toSearchbar.frame
         let newFrame = CGRect(x: fromSearchbar.frame.minX, y: fromSearchbar.frame.maxY + leadingSpace, width: oldFrame.width, height: oldFrame.height)
         
          toSearchbar.frame = newFrame
     }
     
-    private func positionSolidCircleVertically(usingFromSearchbar fromSearchbar: UIButton){
+    private func positionSolidCircleVertically(usingFromSearchbar fromSearchbar: UIButton) {
         solidCircle.center.y = fromSearchbar.center.y
     }
     
@@ -227,18 +227,18 @@ class RouteSelectionView: UIView {
         line.frame = newFrame
     }
     
-    private func positionLabelVertically(_ label: UILabel, usingSearchbar searchbar: UIButton){
+    private func positionLabelVertically(_ label: UILabel, usingSearchbar searchbar: UIButton) {
         label.center.y = searchbar.center.y
     }
     
-    private func positionSearchbarView(usingFromSearchbar fromSearchbar: UIButton, usingToSearchbar toSearchbar: UIButton){
+    private func positionSearchbarView(usingFromSearchbar fromSearchbar: UIButton, usingToSearchbar toSearchbar: UIButton) {
         let oldFrame = searcbarView.frame
         let newFrame = CGRect(x: 0, y: lineWidth, width: oldFrame.width, height: topSpace + fromSearchbar.frame.height + leadingSpace + toSearchbar.frame.height + (3*topSpace/4))
         
         searcbarView.frame = newFrame
     }
     
-    private func positionDatepickerButton(usingSearchbarView searchbarView: UIView){
+    private func positionDatepickerButton(usingSearchbarView searchbarView: UIView) {
         let oldFrame = datepickerButton.frame
         let newFrame = CGRect(x: 0,  y: searchbarView.frame.maxY + lineWidth, width: oldFrame.width, height: oldFrame.height)
         
@@ -252,21 +252,21 @@ class RouteSelectionView: UIView {
         topLine.frame = newFrame
     }
     
-    private func positionBottomLine(usingDatepickerButton datepickerButton: UIButton){
+    private func positionBottomLine(usingDatepickerButton datepickerButton: UIButton) {
         let oldFrame = bottomLine.frame
         let newFrame = CGRect(x: 0, y: datepickerButton.frame.maxY - lineWidth, width: oldFrame.width, height: oldFrame.height)
         
         bottomLine.frame = newFrame
     }
     
-    private func resizeSearchbar(_ searchbar: UIButton, usingSwapButton swapButton: UIButton){
+    private func resizeSearchbar(_ searchbar: UIButton, usingSwapButton swapButton: UIButton) {
         var resizedSearchbarFrame = searchbar.frame
         resizedSearchbarFrame.size.width = self.frame.width - searchbar.frame.minX - swapButton.frame.width - 2*swapPadding
         
         searchbar.frame = resizedSearchbarFrame
     }
     
-    private func positionSwapButton(usingFromSearchBar fromSearchbar: UIButton, usingLine line: UIView){
+    private func positionSwapButton(usingFromSearchBar fromSearchbar: UIButton, usingLine line: UIView) {
         let oldFrame = swapButton.frame
         let newFrame = CGRect(x: fromSearchbar.frame.maxX + swapPadding, y: oldFrame.minY, width: oldFrame.width, height: oldFrame.height)
         
@@ -277,7 +277,7 @@ class RouteSelectionView: UIView {
     
     // MARK: Add subviews
     
-    func addSubviews(){
+    func addSubviews() {
         addSubview(searcbarView)
         searcbarView.addSubview(fromSearchbar)
         searcbarView.addSubview(fromLabel)

--- a/TCAT/Views/WalkWithDistanceIcon.swift
+++ b/TCAT/Views/WalkWithDistanceIcon.swift
@@ -10,6 +10,11 @@ import UIKit
 
 class WalkWithDistanceIcon: UIView {
 
+    // MARK: Size vars
+    
+    let width: CGFloat
+    let height: CGFloat
+    
     // MARK: View vars
     
     var walkIcon: UIImageView
@@ -18,7 +23,15 @@ class WalkWithDistanceIcon: UIView {
     // MARK: Spacing vars
     
     let walkIconAndDistanceLabelVerticalSpace: CGFloat = 2.0
+    
+    // MARK: Constraint var
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: width, height: height)
+    }
 
+    // MARK: Init
+    
     init(withDistance distance: Double) {
         travelDistanceLabel = UILabel()
         travelDistanceLabel.font = UIFont(name: Constants.Fonts.SanFrancisco.Regular, size: 12.0)
@@ -33,8 +46,8 @@ class WalkWithDistanceIcon: UIView {
         walkIcon.contentMode = .scaleAspectFit
         walkIcon.tintColor = .mediumGrayColor
         
-        let width: CGFloat = travelDistanceLabel.frame.width > 0 ? travelDistanceLabel.frame.width : 34.0
-        let height: CGFloat = walkIcon.frame.height + walkIconAndDistanceLabelVerticalSpace + travelDistanceLabel.frame.height
+        width = travelDistanceLabel.frame.width > 0 ? travelDistanceLabel.frame.width : 34.0
+        height = walkIcon.frame.height + walkIconAndDistanceLabelVerticalSpace + travelDistanceLabel.frame.height
         
         super.init(frame: CGRect(origin: CGPoint.zero, size:  CGSize(width: width, height: height)))
         


### PR DESCRIPTION
**Spacing issues addressed:**

- route line resizes based on if stop label is single (20 px) or multiline (28 px)
- when there is no live data on card, spacing from travel time to route diagram has been fixed so has proper spacing
- spacing from the bottom of the route diagram to the bottom of cell has been fixed so it is the same as space of travel time label from top of cell
- spacing at top of tableview fixed to reflect pixel spacing on Zeplin (12 px)

All thanks to autolayout anchor constraints and stackviews!

**Spacing issues to address in next UI haul:**

- space from From search bar (the one that says "Current Location") to the top of the navigation bar is wrong