### PR TITLE
Analytics: Home Screen Quick Actions + Critical Fix

### DIFF
--- a/TCAT/AppDelegate.swift
+++ b/TCAT/AppDelegate.swift
@@ -125,6 +125,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if let navController = window?.rootViewController as? UINavigationController {
                 navController.pushViewController(optionsVC, animated: true)
             }
+            let payload = HomeScreenQuickActionUsedPayload(name: destination.name)
+            Analytics.shared.log(payload)
         }
     }
 

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -378,7 +378,7 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
                 
                 Network.getRoutes(startCoord: startCoord, endCoord: endCoord, endPlaceName: searchFrom.name, time: time, type: self.searchTimeType) { request in
                     let requestUrl = Network.getRequestUrl(startCoord: startCoord, endCoord: endCoord, destinationName: searchTo.name, time: time, type: self.searchTimeType)
-                    self.processRequest(request: request, requestUrl: requestUrl, endPlace: searchFrom)
+                    self.processRequest(request: request, requestUrl: requestUrl, endPlace: searchTo)
                 }
                 
             }
@@ -426,9 +426,7 @@ class RouteOptionsViewController: UIViewController, UITableViewDelegate, UITable
                         }
         )
         
-        let payload = DestinationSearchedEventPayload(destination: endPlace.name,
-                                                      requestUrl: requestUrl,
-                                                      stopType: nil)
+        let payload = DestinationSearchedEventPayload(destination: endPlace.name, requestUrl: requestUrl)
         Analytics.shared.log(payload)
     }
     

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -97,7 +97,6 @@ struct GooglePlaceTappedPayload: Payload {
     let name: String
 }
 
-// MARK: Important
 /// Log front end route calculation
 struct DestinationSearchedEventPayload: Payload {
     static let eventName: String = "Destination Searched"
@@ -105,7 +104,6 @@ struct DestinationSearchedEventPayload: Payload {
     
     let destination: String
     let requestUrl: String?
-    let stopType: String?
 }
 
 /// Log tap on route leading to Route Detail view
@@ -173,4 +171,11 @@ struct ScreenshotTakenPayload: Payload {
     let deviceInfo = DeviceInfo()
     
     let location: String
+}
+
+struct HomeScreenQuickActionUsedPayload: Payload {
+    static let eventName: String = "Home Screen Quick Action Used"
+    let deviceInfo = DeviceInfo()
+    
+    let name: String
 }


### PR DESCRIPTION
- Added analytics for when home screen quick actions are used to track usage
- Found that `DestinationSearchedPayload` was logging `searchFrom`, which has overwhelmingly tended to be "Current Location". We care about the `searchTo` place, which has the destination people care about.