### PR TITLE
Use snapkit to layout busLocationView

### DIFF
--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -73,7 +73,7 @@ class RouteDetailContentViewController: UIViewController {
         routeDetailViewController.navigationItem.setRightBarButton(shareButton, animated: true)
 
         // Debug Function
-        // createDebugBusIcon()
+//        createDebugBusIcon()
     }
 
     /** Construct Directions based on Route and parse Waypoint / Path data */
@@ -262,7 +262,6 @@ class RouteDetailContentViewController: UIViewController {
             CATransaction.begin()
             CATransaction.setAnimationDuration(liveTrackingNetworkRefreshRate + latencyConstant)
 
-            guard let iconView = bus.iconView as? BusLocationView else { return }
             newBus.appearAnimation = .none
 
             updateUserData(for: newBus, with: [
@@ -272,8 +271,6 @@ class RouteDetailContentViewController: UIViewController {
 
             // Position
             newBus.position = busCoords
-            // Actual Coordinates, Bearing
-            iconView.updateBus(from: existingBus!.position, to: busCoords)
 
             CATransaction.commit()
 
@@ -291,9 +288,6 @@ class RouteDetailContentViewController: UIViewController {
                 Constants.BusUserData.actualCoordinates: busCoords,
                 Constants.BusUserData.vehicleID: bus.vehicleID
                 ])
-
-            // Actual Coordinates, Bearing
-            iconView.updateBus(to: busCoords, with: Double(bus.heading))
 
             setIndex(of: marker, with: .bussing)
             marker.map = mapView
@@ -672,12 +666,9 @@ extension RouteDetailContentViewController: GMSMapViewDelegate {
 extension RouteDetailContentViewController {
     /// Create fake bus for debugging and testing bus indicators
     private func createDebugBusIcon() {
-        let bus = BusLocation(dataType: .validData, destination: "", deviation: 0, delay: 0, direction: "", displayStatus: "", gpsStatus: 0, heading: 0, lastStop: "", lastUpdated: Date(), latitude: 42.4491411, longitude: -76.4836815, name: "16", opStatus: "", routeID: 0, runID: 0, speed: 0, tripID: 0, vehicleID: 0)
+        let bus = BusLocation(dataType: .validData, destination: "", deviation: 0, delay: 0, direction: "", displayStatus: "", gpsStatus: 0, heading: 0, lastStop: "", lastUpdated: Date(), latitude: 42.4491411, longitude: -76.4836815, name: "16", opStatus: "", routeID: 10, runID: 0, speed: 0, tripID: 0, vehicleID: 0)
         let coords = CLLocationCoordinate2D(latitude: 42.4491411, longitude: -76.4836815)
         let marker = GMSMarker(position: coords)
-        if let iconView = bus.iconView as? BusLocationView {
-            iconView.updateBus(to: coords, with: Double(bus.heading))
-        }
         marker.iconView = bus.iconView
         marker.appearAnimation = .pop
         setIndex(of: marker, with: .bussing)

--- a/TCAT/Views/BusLocationView.swift
+++ b/TCAT/Views/BusLocationView.swift
@@ -9,171 +9,61 @@
 import CoreLocation
 import UIKit
 
-extension UIView {
-    func addShadow(shadowOffset: CGSize, shadowRadius: CGFloat) {
-        layer.shadowColor = Colors.black.cgColor
-        layer.shadowOffset = shadowOffset
-        layer.shadowOpacity = 0.33
-        layer.shadowRadius = shadowRadius
-    }
-}
-
 class BusLocationView: UIView {
 
-    var busIcon: BusIcon!
+    private var busIcon: BusIcon!
+    private let busLocationBackgroundView = UIImageView(image: #imageLiteral(resourceName: "busBackground"))
+    private let circle = UIView()
 
-    private var bearingIndicator = UIImageView()
-    private var circle = UIView()
-
-    /// The current position of the bearing icon
-    var currentBearing: Double = 0
-
-    /// The actual coordinates of the bus on a map
-    var position: CLLocationCoordinate2D!
+    private let circleSize = CGSize(width: 7, height: 7)
 
     init(number: Int, bearing: Int, position: CLLocationCoordinate2D) {
+        super.init(frame: .zero)
 
-        let background = UIImageView(image: #imageLiteral(resourceName: "busBackground"))
-        let indicator = UIImageView(image: #imageLiteral(resourceName: "bearing"))
+        frame.size = busLocationBackgroundView.frame.size
 
-        super.init(frame: CGRect(x: 0, y: -1 * indicator.frame.height, width: background.frame.width, height: background.frame.height))
-        self.position = position
+        addSubview(busLocationBackgroundView)
+        setupBusIcon(number: number)
+        setupCircle()
 
-        let base = background
-        addSubview(base)
+        setupConstraints()
+    }
 
+    private func setupBusIcon(number: Int) {
         busIcon = BusIcon(type: .liveTracking, number: number)
-        busIcon.center.x = base.center.x
-        busIcon.frame.origin.y = 6
         addSubview(busIcon)
+    }
 
-        bearingIndicator = indicator
-        bearingIndicator.center.x = center.x
-        bearingIndicator.frame.origin.y = 44 - (bearingIndicator.frame.width / 2)
-        addSubview(bearingIndicator)
-        bearingIndicator.transform = CGAffineTransform(rotationAngle: .pi)
-        bearingIndicator.isHidden = true
-
-        // Bearing too unpredictable. Using static circle for now.
-        circle = UIView(frame: CGRect(x: 0, y: 0, width: indicator.frame.height / 2, height: indicator.frame.height / 2))
-        circle.center.x = center.x
-        circle.frame.origin.y = 44 - (circle.frame.width / 2)
-        circle.layer.cornerRadius = circle.frame.width / 2
+    private func setupCircle() {
+        circle.clipsToBounds = true
+        circle.layer.cornerRadius = circleSize.width / 2
         circle.backgroundColor = Colors.tcatBlue
         addSubview(circle)
-        circle.isHidden = false
-
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
+    private func setupConstraints() {
+        let busIconToBusLocationBackgroundViewTopInset = 6
+        let circleToBusLocationBackgroundViewBottomInset = 6
 
-    /// Update the coordinates and bearing of the bus
-    func updateBus(from oldCoords: CLLocationCoordinate2D? = nil, to newCoords: CLLocationCoordinate2D? = nil, with heading: Double? = nil) {
-        if let newCoords = newCoords { position = newCoords }
-        setBearing(start: oldCoords, end: newCoords, heading: heading)
-    }
-
-    /// Toggle between circle and indicator, or specifically set the circle to one value and bearing the opposite
-    func setCircle(isVisible: Bool) {
-        circle.isHidden = !isVisible
-        bearingIndicator.isHidden = !circle.isHidden
-    }
-
-    // Calculate and transform bearing based on change in location or provided heading
-    private func setBearing(start: CLLocationCoordinate2D? = nil, end: CLLocationCoordinate2D? = nil, heading: Double? = nil) {
-
-        // Latitude: North / South, Longitude: East / West
-        if let start = start, let end = end {
-
-            // If no location change, don't change anything
-            let latDelta = end.latitude - start.latitude
-            let longDelta = end.longitude - start.longitude
-            if latDelta == 0 || longDelta == 0 {
-                return
-            }
-
-            // Calulcate bearing from start and end points based on location change
-            let degrees = (getBearingBetween(start, end) + 360).truncatingRemainder(dividingBy: 360)
-            let newDegrees = degrees - self.currentBearing
-            let currentAngle = CGFloat(-1) * CGFloat(self.degreesToRadians(newDegrees))
-            self.bearingIndicator.transform = CGAffineTransform(rotationAngle: CGFloat(-1) * CGFloat(degreesToRadians(currentBearing)))
-            self.bearingIndicator.transform = CGAffineTransform(rotationAngle: currentAngle)
-            self.currentBearing = newDegrees
-
-        } else if let heading = heading {
-
-            // Use endpoint-provided value to change bearing
-            let resetFromAngle = CGFloat(degreesToRadians(currentBearing))
-            let setToAngle = CGFloat(-1) * CGFloat(degreesToRadians(heading))
-            self.bearingIndicator.transform = CGAffineTransform(rotationAngle: resetFromAngle)
-            self.bearingIndicator.transform = CGAffineTransform(rotationAngle: setToAngle)
-            self.currentBearing = heading
-
-        } else {
-            print("setBearing error: no parameters passed in")
+        busLocationBackgroundView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.size.equalTo(busLocationBackgroundView.intrinsicContentSize)
         }
 
-    }
+        busIcon.snp.makeConstraints { make in
+            make.centerX.equalTo(busLocationBackgroundView)
+            make.top.equalToSuperview().inset(busIconToBusLocationBackgroundViewTopInset)
+            make.size.equalTo(busIcon.intrinsicContentSize)
+        }
 
-    func getBearingBetween(_ point1: CLLocationCoordinate2D, _ point2: CLLocationCoordinate2D) -> Double {
-
-        let lat1 = degreesToRadians(point1.latitude)
-        let lon1 = degreesToRadians(point1.longitude)
-        let lat2 = degreesToRadians(point2.latitude)
-        let lon2 = degreesToRadians(point2.longitude)
-
-        let dLon = lon2 - lon1
-
-        let y = sin(dLon) * cos(lat2)
-        let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
-        let radiansBearing = atan2(y, x)
-
-        return radiansToDegrees(radiansBearing)
-
-    }
-
-    func degreesToRadians(_ degrees: Any) -> Double {
-        let value = degrees as? Double ?? Double(degrees as! Int)
-        return value * .pi / 180
-    }
-
-    func radiansToDegrees(_ radians: Any) -> Double {
-        let value = radians as? Double ?? Double(radians as! Int)
-        return value * 180 / .pi
-    }
-
-}
-
-class TriangleView: UIView {
-
-    var color: UIColor!
-
-    init(frame: CGRect, color: UIColor = Colors.white) {
-        self.color = color
-        super.init(frame: frame)
-        self.backgroundColor = .clear
+        circle.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(busLocationBackgroundView).inset(circleToBusLocationBackgroundViewBottomInset)
+            make.size.equalTo(circleSize)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-
-    override func draw(_ rect: CGRect) {
-
-        guard let context = UIGraphicsGetCurrentContext()
-            else { return }
-
-        context.beginPath()
-        context.move(to: CGPoint(x: rect.minX, y: rect.minY))
-        context.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
-        context.addLine(to: CGPoint(x: (rect.maxX / 2.0), y: rect.maxY))
-        context.closePath()
-
-        context.setFillColor(color.cgColor)
-        context.fillPath()
-
-    }
-
 }


### PR DESCRIPTION
Seems like a LOT of the code we had in busLocationView was unused. 

Before deleting the `bearingIndicator`, I made sure that there was no code that was using or altering it. Before I had deleted, it was being initialized but set to hidden, and there was a function that could potentially unhide it but it was never being access.

Lastly, we still need to set the frame.size of the view because we use this within googleMaps' SDK as a marker and that I guess uses frame-based layout. So I removed as much frame-based layout as possible but technically not *all*
