### PR TITLE
Update to use new PlaceIDCoordinates route from backend

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,6 @@ target 'TCAT' do
     
     # Location
     pod 'GoogleMaps', '~> 3.1'
-    pod 'GooglePlaces', '~>  3.1'
     
     # Networking + Data
     pod 'SwiftyJSON', '~> 5.0'

--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -1071,14 +1071,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TCAT/Pods-TCAT-resources.sh",
 				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-				"${PODS_ROOT}/GooglePlaces/Frameworks/GooglePlaces.framework/Resources/GooglePlaces.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMaps.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GooglePlaces.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		BFCA712D206AC69000E4CCE5 /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCA712C206AC69000E4CCE5 /* Keys.swift */; };
 		BFEDB85B2232F22100052D49 /* GeneralTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEDB85A2232F22100052D49 /* GeneralTableViewCell.swift */; };
 		BFF41EB2204365E800E0696B /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF41EB1204365E800E0696B /* SummaryView.swift */; };
+		C2240435231838C300095C5C /* PlaceCoordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2240434231838C300095C5C /* PlaceCoordinates.swift */; };
 		D183AA021E6CB092006A9A15 /* Extensions+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = D183AA011E6CB092006A9A15 /* Extensions+App.swift */; };
 		D94BD3042159A21800C9214E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D94BD2FE2159994400C9214E /* GoogleService-Info.plist */; };
 		DC2E96441FBF41CB009955C6 /* FavoritesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2E96431FBF41CB009955C6 /* FavoritesTableViewController.swift */; };
@@ -289,6 +290,7 @@
 		BFD5B4E31FAADFAE00955C37 /* WalkPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WalkPath.swift; path = Model/WalkPath.swift; sourceTree = "<group>"; };
 		BFEDB85A2232F22100052D49 /* GeneralTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GeneralTableViewCell.swift; path = Cells/GeneralTableViewCell.swift; sourceTree = "<group>"; };
 		BFF41EB1204365E800E0696B /* SummaryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SummaryView.swift; path = Views/SummaryView.swift; sourceTree = "<group>"; };
+		C2240434231838C300095C5C /* PlaceCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceCoordinates.swift; sourceTree = "<group>"; };
 		CC27BD081FF6C91C00DAA7D5 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Analytics.swift; path = Utilities/Analytics.swift; sourceTree = "<group>"; };
 		D183AA011E6CB092006A9A15 /* Extensions+App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Extensions+App.swift"; path = "Utilities/Extensions+App.swift"; sourceTree = "<group>"; };
 		D94BD2FC2159993D00C9214E /* Keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Keys.plist; path = "Supporting Files/Keys.plist"; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 				BFD5B4E31FAADFAE00955C37 /* WalkPath.swift */,
 				DDB49C9C1E8857FC00A99C35 /* Waypoint.swift */,
 				BF40D7642230385B000ED7D8 /* WhatsNewCard.swift */,
+				C2240434231838C300095C5C /* PlaceCoordinates.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -1094,6 +1097,7 @@
 				5006F7BA1EC0F59A005ACAF2 /* SearchTableViewHelpers.swift in Sources */,
 				BFCA712D206AC69000E4CCE5 /* Keys.swift in Sources */,
 				22D76E8F2263E21F00FA21B9 /* HomeOptionsCardViewController.swift in Sources */,
+				C2240435231838C300095C5C /* PlaceCoordinates.swift in Sources */,
 				BF40D7652230385B000ED7D8 /* WhatsNewCard.swift in Sources */,
 				DDB49C9D1E8857FC00A99C35 /* BusPath.swift in Sources */,
 				BFF41EB2204365E800E0696B /* SummaryView.swift in Sources */,

--- a/TCAT/AppDelegate.swift
+++ b/TCAT/AppDelegate.swift
@@ -94,6 +94,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func patchFunctions(rootVC: UIViewController) {
         if
+            VersionStore.shared.savedAppVersion <= WhatsNew.Version(major: 1, minor: 2, patch: 1),
             let homeViewController = rootVC as? HomeMapViewController
         {
             print("Begin Data Migration")
@@ -105,20 +106,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 Analytics.shared.log(payload)
             }
         }
-        
-//        if
-//            VersionStore.shared.savedAppVersion <= WhatsNew.Version(major: 1, minor: 2, patch: 1),
-//            let homeViewController = rootVC as? HomeMapViewController
-//        {
-//            print("Begin Data Migration")
-//            homeViewController.showLoadingScreen()
-//            migrationToNewPlacesModel { (success, errorDescription) in
-//                homeViewController.removeLoadingScreen()
-//                print("Data Migration Complete - Success: \(success), Error: \(errorDescription ?? "n/a")")
-//                let payload = DataMigrationOnePointThreePayload(success: success, errorDescription: errorDescription)
-//                Analytics.shared.log(payload)
-//            }
-//        }
 
         // v1.4.1 Delete Corrupted Shortcut Donations
         if VersionStore.shared.savedAppVersion <= WhatsNew.Version(major: 1, minor: 4, patch: 0) {

--- a/TCAT/AppDelegate.swift
+++ b/TCAT/AppDelegate.swift
@@ -11,7 +11,6 @@ import Fabric
 import Firebase
 import FutureNova
 import GoogleMaps
-import GooglePlaces
 import Intents
 import SafariServices
 import SwiftyJSON
@@ -41,8 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set Up Google Services
         FirebaseApp.configure()
         GMSServices.provideAPIKey(Keys.googleMaps.value)
-        GMSPlacesClient.provideAPIKey(Keys.googlePlaces.value)
-        
+
         // Update shortcut items
         AppShortcuts.shared.updateShortcutItems()
 
@@ -192,10 +190,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
                 dispatchGroup.leave()
             }
-        } else {
-            print("here")
         }
-        
+
         // Recent Searches Data
         let recentSearchesKey = Constants.UserDefaults.recentSearch
         

--- a/TCAT/AppDelegate.swift
+++ b/TCAT/AppDelegate.swift
@@ -59,7 +59,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         for (key, defaultValue) in userDataInits {
             if userDefaults.value(forKey: key) == nil {
-                if key == Constants.UserDefaults.favorites {
+                if key == Constants.UserDefaults.favorites && sharedUserDefaults?.value(forKey: key) == nil {
                     sharedUserDefaults?.set(defaultValue, forKey: key)
                 } else {
                     userDefaults.set(defaultValue, forKey: key)
@@ -95,9 +95,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func patchFunctions(rootVC: UIViewController) {
-        
         if
-            VersionStore.shared.savedAppVersion <= WhatsNew.Version(major: 1, minor: 2, patch: 1),
             let homeViewController = rootVC as? HomeMapViewController
         {
             print("Begin Data Migration")
@@ -110,6 +108,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
+//        if
+//            VersionStore.shared.savedAppVersion <= WhatsNew.Version(major: 1, minor: 2, patch: 1),
+//            let homeViewController = rootVC as? HomeMapViewController
+//        {
+//            print("Begin Data Migration")
+//            homeViewController.showLoadingScreen()
+//            migrationToNewPlacesModel { (success, errorDescription) in
+//                homeViewController.removeLoadingScreen()
+//                print("Data Migration Complete - Success: \(success), Error: \(errorDescription ?? "n/a")")
+//                let payload = DataMigrationOnePointThreePayload(success: success, errorDescription: errorDescription)
+//                Analytics.shared.log(payload)
+//            }
+//        }
+
         // v1.4.1 Delete Corrupted Shortcut Donations
         if VersionStore.shared.savedAppVersion <= WhatsNew.Version(major: 1, minor: 4, patch: 0) {
             print("Begin Deleting Corrupt Shortcut Donations")
@@ -168,7 +180,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let storedPlaces = userDefaults.value(forKey: favoritesKey) as? Data,
             let favorites = NSKeyedUnarchiver.unarchiveObject(with: storedPlaces) as? [Any]
         {
-            // This will only fire on legacy verisions and models
+            // This will only fire on legacy versions and models
             dispatchGroup.enter()
             convertDataToPlaces(data: favorites) { (places, error) in
                 if let encodedObject = try? self.encoder.encode(places), error == nil {
@@ -180,6 +192,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
                 dispatchGroup.leave()
             }
+        } else {
+            print("here")
         }
         
         // Recent Searches Data

--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -184,7 +184,7 @@ extension FavoritesTableViewController: UISearchBarDelegate {
                     switch result {
                     case .value(let response):
                         if response.success {
-                            self.resultsSection = Section.searchResults(items: [])
+                            self.resultsSection = Section.searchResults(items: response.data)
                         } else {
                             print("[FavoritesTableViewController] success: false")
                             self.resultsSection = Section.searchResults(items: [])

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -416,7 +416,6 @@ extension RouteOptionsViewController: RouteSelectionViewDelegate {
     }
 
     func showDatePicker() {
-
         view.bringSubviewToFront(datePickerOverlay)
         view.bringSubviewToFront(datePickerView)
 
@@ -428,8 +427,10 @@ extension RouteOptionsViewController: RouteSelectionViewDelegate {
         datePickerView.setDatepickerTimeType(searchTimeType: searchTimeType)
 
         UIView.animate(withDuration: 0.5) {
-            self.datePickerView.center.y = self.view.frame.height - (self.datePickerView.frame.height/2)
+            self.setupConstraintsForVisibleDatePickerView()
             self.datePickerOverlay.alpha = 0.6 // darken screen when pull up datepicker
+
+            self.view.layoutIfNeeded()
         }
 
         let payload = RouteOptionsSettingsPayload(description: "Date Picker Accessed")

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -195,7 +195,7 @@ class RouteOptionsViewController: UIViewController {
         hideSearchBar()
     }
 
-    private func setupConstraintsForVisibleDatePickerView() {
+    func setupConstraintsForVisibleDatePickerView() {
         datePickerView.snp.remakeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
             make.height.equalTo(self.datePickerView.frame.height)
@@ -234,20 +234,6 @@ class RouteOptionsViewController: UIViewController {
     }
 
     // MARK: Search bar
-
-    @objc private func searchingTo(sender: UIButton? = nil) {
-        searchType = .to
-        presentSearchBar()
-        let payload = RouteOptionsSettingsPayload(description: "Searching To Tapped")
-        Analytics.shared.log(payload)
-    }
-
-    @objc private func searchingFrom(sender: UIButton? = nil) {
-        searchType = .from
-        presentSearchBar()
-        let payload = RouteOptionsSettingsPayload(description: "Searching From Tapped")
-        Analytics.shared.log(payload)
-    }
 
     func presentSearchBar() {
         var placeholder = ""
@@ -570,31 +556,6 @@ class RouteOptionsViewController: UIViewController {
 
         showRouteSearchingLoader = false
         routeResults.reloadData()
-    }
-
-    // MARK: Date Picker
-    @objc private func showDatePicker(sender: UIButton) {
-
-        view.bringSubviewToFront(datePickerOverlay)
-        view.bringSubviewToFront(datePickerView)
-
-        // set up date on datepicker view
-        if let time = searchTime {
-            datePickerView.setDatepickerDate(date: time)
-        }
-
-        datePickerView.setDatepickerTimeType(searchTimeType: searchTimeType)
-
-        UIView.animate(withDuration: 0.5) {
-            self.setupConstraintsForVisibleDatePickerView()
-            self.datePickerOverlay.alpha = 0.6 // darken screen when pull up datepicker
-
-            self.view.layoutIfNeeded()
-        }
-
-        let payload = RouteOptionsSettingsPayload(description: "Date Picker Accessed")
-        Analytics.shared.log(payload)
-
     }
 
     // MARK: Reachability

--- a/TCAT/Model/Route.swift
+++ b/TCAT/Model/Route.swift
@@ -143,6 +143,7 @@ class Route: NSObject, Codable {
                     let newDirection = direction.copy() as! Direction
                     newDirection.type = newDirection.type == .depart ? .arrive : .walk
                     newDirection.stayOnBusForTransfer = false
+                    newDirection.name = endName
                     rawDirections.append(newDirection)
                 }
             }

--- a/TCAT/Network/Endpoints.swift
+++ b/TCAT/Network/Endpoints.swift
@@ -78,6 +78,11 @@ extension Endpoint {
 
     }
 
+    static func getPlaceIDCoordinates(placeID: String) -> Endpoint {
+        let body = PlaceIDCoordinatesBody(placeID: placeID)
+        return Endpoint(path: Constants.Endpoints.placeIDCoordinates, body: body)
+    }
+
     static func getSearchResults(searchText: String) -> Endpoint {
         let body = SearchResultsBody(query: searchText)
         return Endpoint(path: Constants.Endpoints.searchResults, body: body)

--- a/TCAT/Network/Models.swift
+++ b/TCAT/Network/Models.swift
@@ -28,6 +28,10 @@ internal struct MultiRoutesBody: Codable {
     let destinationNames: [String]
 }
 
+internal struct PlaceIDCoordinatesBody: Codable {
+    let placeID: String
+}
+
 internal struct SearchResultsBody: Codable {
     let query: String
 }

--- a/TCAT/PlaceCoordinates.swift
+++ b/TCAT/PlaceCoordinates.swift
@@ -1,0 +1,14 @@
+//
+//  PlaceCoordinates.swift
+//  TCAT
+//
+//  Created by Kevin Chan on 8/29/19.
+//  Copyright © 2019 cuappdev. All rights reserved.
+//
+
+import Foundation
+
+struct PlaceCoordinates: Codable {
+    let lat: Double
+    let long: Double
+}

--- a/TCAT/Supporting Files/Constants.swift
+++ b/TCAT/Supporting Files/Constants.swift
@@ -166,6 +166,7 @@ struct Constants {
         static let delay = "/delay"
         static let getRoutes = "/route"
         static let multiRoute = "/multiroute"
+        static let placeIDCoordinates = "/placeIDCoordinates"
         static let routeSelected = "/routeSelected"
         static let searchResults = "/search"
     }

--- a/TCAT/Utilities/CoordinateVisitor.swift
+++ b/TCAT/Utilities/CoordinateVisitor.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 cuappdev. All rights reserved.
 //
 
-import GooglePlaces
+import FutureNova
 import UIKit
 
 struct CoordinateVisitorError: Swift.Error {
@@ -16,35 +16,38 @@ struct CoordinateVisitorError: Swift.Error {
 
 class CoordinateVisitor: NSObject {
 
-    static private let placesClient = GMSPlacesClient.shared()
+    static private let networking: Networking = URLSession.shared.request
 
     static func getCoordinates(for place: Place, callback: @escaping (_ latitude: Double?, _ longitude: Double?, _ error: CoordinateVisitorError?) -> Void) {
 
         let identifier = place.placeIdentifier ?? ""
 
-        placesClient.lookUpPlaceID(identifier) { (result, error) in
-
-            if let error = error {
-                let coordVisitError = CoordinateVisitorError(
-                    title: "Google Places Lookup",
-                    description: "PlaceVisitor visit(place:) lookup place id query error: \(error.localizedDescription)"
-                )
-                callback(nil, nil, coordVisitError)
-                return
+        getPlaceIDCoordinates(placeID: identifier).observe { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .value(let response):
+                    if response.success {
+                        callback(response.data.lat, response.data.long, nil)
+                    } else {
+                        let coordVisitError = CoordinateVisitorError(
+                            title: "Place ID Coordinates Lookup",
+                            description: "Place ID Coordinates lookup failure"
+                        )
+                        callback(nil, nil, coordVisitError)
+                    }
+                case .error(let error):
+                    let coordVisitError = CoordinateVisitorError(
+                        title: "Place ID Coordinates Lookup",
+                        description: "Place ID Coordinates lookup error: \(error.localizedDescription)"
+                    )
+                    callback(nil, nil, coordVisitError)
+                }
             }
-
-            guard let result = result else {
-                let coordVisitError = CoordinateVisitorError(
-                    title: "PlaceResult is nil",
-                    description: "Network visit(place:) result is nil for \(place.name) with id \(identifier)"
-                )
-                callback(nil, nil, coordVisitError)
-                return
-            }
-
-            callback(result.coordinate.latitude, result.coordinate.longitude, nil)
         }
+    }
 
+    private static func getPlaceIDCoordinates(placeID: String) -> Future<Response<PlaceCoordinates>> {
+        return networking(Endpoint.getPlaceIDCoordinates(placeID: placeID)).decode()
     }
 
 }

--- a/TCAT/Views/RouteSelectionView.swift
+++ b/TCAT/Views/RouteSelectionView.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-@objc protocol RouteSelectionViewDelegate: class {
-    @objc func swapFromAndTo()
-    @objc func showDatePicker()
-    @objc func searchingFrom()
-    @objc func searchingTo()
+protocol RouteSelectionViewDelegate: class {
+    func swapFromAndTo()
+    func showDatePicker()
+    func searchingFrom()
+    func searchingTo()
 }
 
 class RouteSelectionView: UIView {
@@ -216,10 +216,10 @@ class RouteSelectionView: UIView {
     func configure(delegate: RouteSelectionViewDelegate?, from: String, to: String) {
         self.delegate = delegate
 
-        toSearchbar.addTarget(self, action: #selector(delegate?.searchingTo), for: .touchUpInside)
-        fromSearchbar.addTarget(self, action: #selector(delegate?.searchingFrom), for: .touchUpInside)
-        datepickerButton.addTarget(self, action: #selector(delegate?.showDatePicker), for: .touchUpInside)
-        swapButton.addTarget(self, action: #selector(delegate?.swapFromAndTo), for: .touchUpInside)
+        toSearchbar.addTarget(self, action: #selector(forwardSearchingTo), for: .touchUpInside)
+        fromSearchbar.addTarget(self, action: #selector(forwardSearchingFrom), for: .touchUpInside)
+        datepickerButton.addTarget(self, action: #selector(forwardShowDatePicker), for: .touchUpInside)
+        swapButton.addTarget(self, action: #selector(forwardSwapFromAndTo), for: .touchUpInside)
 
         updateSearchBarTitles(from: from, to: to)
     }
@@ -232,6 +232,22 @@ class RouteSelectionView: UIView {
         if let to = to {
             toSearchbar.setTitle(to, for: .normal)
         }
+    }
+
+    @objc private func forwardSearchingTo() {
+        delegate?.searchingTo()
+    }
+
+    @objc private func forwardSearchingFrom() {
+        delegate?.searchingFrom()
+    }
+
+    @objc private func forwardShowDatePicker() {
+        delegate?.showDatePicker()
+    }
+
+    @objc private func forwardSwapFromAndTo() {
+        delegate?.swapFromAndTo()
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This PR:
- Now fetches the placeID coordinates from backend using the new `/placesIDCoordinate` route
- Fixes issue where `favorites` wasn't persisting between app launches
- Fixes app crashing when tapping on the `From` textfield in a search