### PR TITLE
[Very easy] Stop using current location to show route

### DIFF
--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -575,7 +575,6 @@ extension RouteDetailContentViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let newCoord = locations.last?.coordinate {
-            bounds = bounds.includingCoordinate(newCoord)
             currentLocation = newCoord
         }
         didUpdateLocation()


### PR DESCRIPTION
Idk y we were using current location to show the route overview but I took it out because it was causing problems especially when the user is out of state. Furthermore, I found that for cases where the user isn't using current location and simply searching from one place to another, including the current location in the zoomed in map view didn't seem to be very useful.

### New
<img width="200" alt="Screen Shot 2019-08-29 at 10 56 49 PM" src="https://user-images.githubusercontent.com/36868927/63990008-60499280-cab0-11e9-94c7-9f43a68d6c23.png">

### Old
<img width="200" alt="Screen Shot 2019-08-29 at 10 56 26 PM" src="https://user-images.githubusercontent.com/36868927/63990010-60499280-cab0-11e9-8f34-a6ff47589e55.png">
