### PR TITLE
Fix stopLabel width and word wrap.

### DIFF
--- a/TCAT/Views/RouteDiagramSegment.swift
+++ b/TCAT/Views/RouteDiagramSegment.swift
@@ -82,6 +82,7 @@ class RouteDiagramSegment: UIView {
 
         stopLabel.snp.makeConstraints { make in
             make.leading.equalTo(stopDot.snp.centerX).offset(spaceBtnStopDotCenterXAndStopLabel)
+            make.trailing.equalToSuperview()
             make.top.equalTo(stopDot)
         }
     }
@@ -89,11 +90,12 @@ class RouteDiagramSegment: UIView {
     // MARK: Get data from route ojbect
 
     private func getStopLabel(withName name: String, withStayOnBusForTranfer stayOnBusForTranfer: Bool, withDistance distance: Double?) -> UILabel {
-        let yPos: CGFloat = 101
-        let rightSpaceFromSuperview: CGFloat = 16
-        let width: CGFloat = UIScreen.main.bounds.width - yPos - rightSpaceFromSuperview
+        let labelPadding: CGFloat = 12
+        let rightPadding: CGFloat = 16
+        let xPos: CGFloat = 101
+        let width: CGFloat = UIScreen.main.bounds.width - xPos - rightPadding - labelPadding
 
-        let stopLabel = UILabel(frame: CGRect(x: 0, y: 0, width: width, height: 17))
+        let stopLabel = UILabel()
         // allow for multi-line label for long stop names
         stopLabel.allowsDefaultTighteningForTruncation = true
         stopLabel.lineBreakMode = .byWordWrapping
@@ -143,7 +145,7 @@ class RouteDiagramSegment: UIView {
         testStopLabel.font = .getFont(.regular, size: 14.0)
         testStopLabel.textColor = Colors.primaryText
         testStopLabel.text = name
-
+        testStopLabel.sizeToFit()
         return testStopLabel
     }
 


### PR DESCRIPTION
- Addresses Issue #279 Text label is being cut off
- Bug screen with text label cut off: 
<img width="300" src="https://user-images.githubusercontent.com/29307883/64380385-d8f3a600-cffe-11e9-8d9a-6700ea13078c.jpg">
- Fixed screen with text wrap: 
<img width="300" alt="Screen Shot 2019-09-05 at 4 58 37 PM" src="https://user-images.githubusercontent.com/29307883/64380344-c7aa9980-cffe-11e9-9869-9bf8d5f92485.png"> <img width="300" alt="Screen Shot 2019-09-05 at 4 53 38 PM" src="https://user-images.githubusercontent.com/29307883/64380938-1278e100-d000-11e9-9803-5bb775096192.png">


- Changes: Auto layout may have been interfering with stopLabel frame, preventing text wrap. I removed the frame and moved the width constraint into auto layout. getTestStopLabel(name) was also incorrectly calculating the testStopLabel width, causing overflow.  