### PR TITLE
Set live elements only for nonwalking routes.

### DIFF
--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -218,11 +218,12 @@ class RouteTableViewCell: UITableViewCell {
         if isWalkingRoute {
             setDepartureTimeToWalking()
             return
+        } else {
+            let delayState = getDelayState(fromRoute: route)
+            setDepartureTime(withStartTime: Date(), withDelayState: delayState)
+            setLiveElements(withDelayState: delayState)
         }
 
-        let delayState = getDelayState(fromRoute: route)
-        setDepartureTime(withStartTime: Date(), withDelayState: delayState)
-        setLiveElements(withDelayState: delayState)
     }
 
     @objc private func updateLiveElementsWithDelay(sender: Timer) {


### PR DESCRIPTION
**Addresses issue #285 Live tracking on walking route**
- Bug: 
![64212669-272a6d00-ce78-11e9-88b9-546ae438e4f9](https://user-images.githubusercontent.com/29307883/64492081-f2366580-d23d-11e9-885d-16473e569d2f.jpg)

- Added else block so that the live components never get rendered for walking routes.
