### PR TITLE
Handle decode error when delay key is missing

### DIFF
--- a/TCAT/Model/Direction.swift
+++ b/TCAT/Model/Direction.swift
@@ -106,7 +106,7 @@ class Direction: NSObject, NSCopying, Codable {
         stops = try container.decode([LocationObject].self, forKey: .stops)
         do { stayOnBusForTransfer = try container.decode(Bool.self, forKey: .stayOnBusForTransfer) } catch { stayOnBusForTransfer = false }
         tripIdentifiers = try container.decode([String]?.self, forKey: .tripIdentifiers)
-        delay = try container.decode(Int?.self, forKey: .delay)
+        do { delay = try container.decode(Int?.self, forKey: .delay) } catch { delay = nil }
         travelDistance = try container.decode(Double.self, forKey: .travelDistance)
         super.init()
     }


### PR DESCRIPTION
Currently, there is a bug where for some searches, even though the backend returns the response, we get a `Could not connect to server` error. After some investigation, I realized its because there was a `Decoding` error where a `Direction` object was sometimes missing the `delay` key` ,as in the following screenshot:

<img width="585" alt="Screen Shot 2019-09-24 at 11 15 04 PM" src="https://user-images.githubusercontent.com/26048121/65566530-2a69c380-df21-11e9-88a7-62ceac6372d2.png">
**Notice how the object in index 0 has a `delay` key but the object in index 1 does not**

To fix this, I wrapped the decoding in a `do {} catch {}`.

Before:
<img width="327" alt="Screen Shot 2019-09-24 at 11 11 48 PM" src="https://user-images.githubusercontent.com/26048121/65566565-45d4ce80-df21-11e9-8967-70e02f96f69f.png">

After:
<img width="325" alt="Screen Shot 2019-09-24 at 11 13 02 PM" src="https://user-images.githubusercontent.com/26048121/65566572-48cfbf00-df21-11e9-95f6-368be82af9f8.png">
