### PR TITLE
Remove setting searchBar properties in viewWillAppear

### DIFF
--- a/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
@@ -16,11 +16,6 @@ extension HomeOptionsCardViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         // Update searchbar attributes
-        if let textFieldInsideSearchBar = searchBar.value(forKey: Constants.SearchBar.searchField) as? UITextField,
-            let searchView = textFieldInsideSearchBar.leftView as? UIImageView {
-            textFieldInsideSearchBar.backgroundColor = Colors.white
-            searchView.image = #imageLiteral(resourceName: "search-large")
-        }
         searchBar.placeholder = Constants.General.searchPlaceholder
         searchBar.text = nil
 


### PR DESCRIPTION
We currently already set the `searchBar` background color and image inside `viewDidLoad` so having the same code in `viewWillAppear` unnecessary. Removing this code also helps with the bug where if you make a search and then go back to the home screen, the search icon becomes HUGE. The bug still exists but the size increase isn't as drastic.

Normal Size:
<img width="317" alt="Screen Shot 2019-09-25 at 4 00 16 PM" src="https://user-images.githubusercontent.com/26048121/65635108-b1fd1400-dfad-11e9-8d53-2e8e8b76e52f.png">


Before:
<img width="322" alt="Screen Shot 2019-09-25 at 3 56 54 PM" src="https://user-images.githubusercontent.com/26048121/65634903-487d0580-dfad-11e9-8ccb-1a05a0f67a45.png">

After:
<img width="322" alt="Screen Shot 2019-09-25 at 3 56 24 PM" src="https://user-images.githubusercontent.com/26048121/65634907-4a46c900-dfad-11e9-9a03-9c7888366f6f.png">