### PR TITLE
iOS13 Fixes before pushing

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,6 +16,7 @@ target 'TCAT' do
     pod 'SwiftyJSON', '~> 5.0'
     pod 'FutureNova', :git => 'https://github.com/cuappdev/ios-networking.git'
     pod 'Wormholy', :configurations => ['Debug']
+    pod 'FLEX', :configurations => ['Debug']
     
     # Analytics
     pod 'Crashlytics', '~> 3.12'

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,6 @@ target 'TCAT' do
     pod 'SwiftyJSON', '~> 5.0'
     pod 'FutureNova', :git => 'https://github.com/cuappdev/ios-networking.git'
     pod 'Wormholy', :configurations => ['Debug']
-    pod 'FLEX', :configurations => ['Debug']
     
     # Analytics
     pod 'Crashlytics', '~> 3.12'

--- a/Siri/Info.plist
+++ b/Siri/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.2</string>
+	<string>1.6.3</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -1021,7 +1021,6 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TCAT/Pods-TCAT-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/DZNEmptyDataSet/DZNEmptyDataSet.framework",
-				"${BUILT_PRODUCTS_DIR}/FLEX/FLEX.framework",
 				"${BUILT_PRODUCTS_DIR}/FutureNova/FutureNova.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/MarqueeLabel/MarqueeLabel.framework",
@@ -1038,7 +1037,6 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DZNEmptyDataSet.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLEX.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FutureNova.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MarqueeLabel.framework",

--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		5006F7BA1EC0F59A005ACAF2 /* SearchTableViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5006F7B91EC0F59A005ACAF2 /* SearchTableViewHelpers.swift */; };
 		502D8F5F1E55161D005280F1 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502D8F5E1E55161D005280F1 /* SearchBarView.swift */; };
 		503EC37D1E969ADF00B3D4D4 /* PlaceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503EC37C1E969ADF00B3D4D4 /* PlaceTableViewCell.swift */; };
-		503EC37F1E969B2100B3D4D4 /* SearchResultsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503EC37E1E969B2100B3D4D4 /* SearchResultsTableViewController.swift */; };
+		503EC37F1E969B2100B3D4D4 /* SearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503EC37E1E969B2100B3D4D4 /* SearchResultsViewController.swift */; };
 		6934655577BDF2398A7C30F5 /* Pods_TCAT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FE444491ABFAAD81EF7AC44 /* Pods_TCAT.framework */; };
 		7E0A65192226367100441967 /* WalkPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD5B4E31FAADFAE00955C37 /* WalkPath.swift */; };
 		7E0C97B5220362C10068439D /* SFProDisplay-Semibold.otf in Resources */ = {isa = PBXBuildFile; fileRef = BF8460A12172A5210027FB62 /* SFProDisplay-Semibold.otf */; };
@@ -238,7 +238,7 @@
 		5006F7B91EC0F59A005ACAF2 /* SearchTableViewHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = SearchTableViewHelpers.swift; path = Utilities/SearchTableViewHelpers.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		502D8F5E1E55161D005280F1 /* SearchBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SearchBarView.swift; path = Views/SearchBarView.swift; sourceTree = "<group>"; };
 		503EC37C1E969ADF00B3D4D4 /* PlaceTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PlaceTableViewCell.swift; path = Cells/PlaceTableViewCell.swift; sourceTree = "<group>"; };
-		503EC37E1E969B2100B3D4D4 /* SearchResultsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = SearchResultsTableViewController.swift; path = Controllers/SearchResultsTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		503EC37E1E969B2100B3D4D4 /* SearchResultsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = SearchResultsViewController.swift; path = Controllers/SearchResultsViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		50A19BAD1E4C214000AD6768 /* HomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = HomeViewController.swift; path = Controllers/HomeViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		7E14AEB12177E661006A344D /* TCAT.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = TCAT.entitlements; path = "Supporting Files/TCAT.entitlements"; sourceTree = "<group>"; };
 		7E14AEC02177E846006A344D /* IntentsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IntentsUI.framework; path = System/Library/Frameworks/IntentsUI.framework; sourceTree = SDKROOT; };
@@ -664,7 +664,7 @@
 				22A83FD3228B85CE005DE4EB /* RouteDetailDrawerViewController+Extensions.swift */,
 				DD2F98A21E5150990005F6BC /* RouteOptionsViewController.swift */,
 				229BD4E8229947D80042D9D3 /* RouteOptionsViewController+Extensions.swift */,
-				503EC37E1E969B2100B3D4D4 /* SearchResultsTableViewController.swift */,
+				503EC37E1E969B2100B3D4D4 /* SearchResultsViewController.swift */,
 				2292486B21B8ECB90004279C /* ServiceAlertsViewController.swift */,
 			);
 			name = Controllers;
@@ -1021,6 +1021,7 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TCAT/Pods-TCAT-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/DZNEmptyDataSet/DZNEmptyDataSet.framework",
+				"${BUILT_PRODUCTS_DIR}/FLEX/FLEX.framework",
 				"${BUILT_PRODUCTS_DIR}/FutureNova/FutureNova.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/MarqueeLabel/MarqueeLabel.framework",
@@ -1037,6 +1038,7 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DZNEmptyDataSet.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLEX.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FutureNova.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MarqueeLabel.framework",
@@ -1156,7 +1158,7 @@
 				DC2E96441FBF41CB009955C6 /* FavoritesTableViewController.swift in Sources */,
 				D183AA021E6CB092006A9A15 /* Extensions+App.swift in Sources */,
 				7EEB14242231A34200134C8B /* Constants.swift in Sources */,
-				503EC37F1E969B2100B3D4D4 /* SearchResultsTableViewController.swift in Sources */,
+				503EC37F1E969B2100B3D4D4 /* SearchResultsViewController.swift in Sources */,
 				DD04B1AD208CC5E4006C1C23 /* JSONFileManager.swift in Sources */,
 				BF6095271FD7091B0013E538 /* CustomNavigationController.swift in Sources */,
 				7EBD9D9A22263107008BF900 /* Circle.swift in Sources */,

--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -1378,7 +1378,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1389,6 +1389,7 @@
 				INFOPLIST_FILE = "TCAT/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 1.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.tcat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1630,7 +1631,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1641,6 +1642,7 @@
 				INFOPLIST_FILE = "TCAT/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 1.6.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -DDEBUG";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "$(inherited) \"-D\" \"COCOAPODS\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.tcat.debug;
@@ -1784,7 +1786,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1795,6 +1797,7 @@
 				INFOPLIST_FILE = "TCAT/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 1.6.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -DLOCAL";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "$(inherited) \"-D\" \"COCOAPODS\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.tcat.debug;

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -299,6 +299,9 @@ class RouteOptionsViewController: UIViewController {
 
     func hideSearchBar() {
         navigationItem.searchController = nil
+        // After removing searchController from navigation bar, we need to call
+        // setNeedsLayout in order to restore the navigation bar to its original height
+        navigationController?.view.setNeedsLayout()
         if let backButton = backButton {
             navigationItem.setLeftBarButton(backButton, animated: false)
         }
@@ -308,6 +311,10 @@ class RouteOptionsViewController: UIViewController {
 
     private func showSearchBar() {
         navigationItem.searchController = searchBarView.searchController
+        // After adding searchController to navigation bar, we need to call
+        // setNeedsLayout in order to for the navigation bar to increase its height
+        // to account for the search bar
+        navigationController?.view.setNeedsLayout()
         backButton = navigationItem.leftBarButtonItem
         navigationItem.setLeftBarButton(nil, animated: false)
         navigationItem.hidesBackButton = true

--- a/TCAT/Controllers/SearchResultsViewController.swift
+++ b/TCAT/Controllers/SearchResultsViewController.swift
@@ -80,9 +80,8 @@ class SearchResultsViewController: UIViewController {
         view.addSubview(tableView)
 
         tableView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
-            make.leading.trailing.equalToSuperview()
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.bottom.equalToSuperview()
         }
 
         // Set Up LocationManager

--- a/TCAT/Supporting Files/Info.plist
+++ b/TCAT/Supporting Files/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -19,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -34,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
@@ -94,6 +92,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/TCAT/Views/SearchBarView.swift
+++ b/TCAT/Views/SearchBarView.swift
@@ -17,7 +17,6 @@ class SearchBarView: UIView, UISearchControllerDelegate {
         super.init(frame: .zero)
 
         //Search Bar Customization
-        UISearchBar.appearance().setImage(UIImage(named: "search"), for: .search, state: .normal)
         UIBarButtonItem.appearance().setTitleTextAttributes([.foregroundColor: Colors.black], for: .normal)
 
         resultsViewController = SearchResultsTableViewController(searchBarCancelDelegate: searchBarCancelDelegate, destinationDelegate: destinationDelegate)

--- a/TCAT/Views/SearchBarView.swift
+++ b/TCAT/Views/SearchBarView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class SearchBarView: UIView, UISearchControllerDelegate {
 
-    var resultsViewController: SearchResultsTableViewController?
+    var resultsViewController: SearchResultsViewController?
     var searchController: UISearchController?
 
     init(searchBarCancelDelegate: SearchBarCancelDelegate? = nil, destinationDelegate: DestinationDelegate? = nil) {
@@ -19,7 +19,7 @@ class SearchBarView: UIView, UISearchControllerDelegate {
         //Search Bar Customization
         UIBarButtonItem.appearance().setTitleTextAttributes([.foregroundColor: Colors.black], for: .normal)
 
-        resultsViewController = SearchResultsTableViewController(searchBarCancelDelegate: searchBarCancelDelegate, destinationDelegate: destinationDelegate)
+        resultsViewController = SearchResultsViewController(searchBarCancelDelegate: searchBarCancelDelegate, destinationDelegate: destinationDelegate)
         searchController = UISearchController(searchResultsController: resultsViewController)
         searchController?.searchResultsUpdater = resultsViewController
         searchController?.searchBar.delegate = resultsViewController

--- a/Today Extension/Info.plist
+++ b/Today Extension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.2</string>
+	<string>1.6.3</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>1</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
This PR fixes some of the more noticeable bugs that appear

- Fix the searchIcon on home screen from becoming extremely big. 
**FIX**: In `RouteOptionsViewController`, we create a `SearchBarView` and for some reason in the `SearchBarView:init`, we were setting the image of UISearchBar globally like so: `UISearchBar.appearance().image...`. I removed this code and now the bug is gone
- In `RouteOptionsViewController`, when you tap on the `From` or `To` textfield and make a search, the top of the tableView from `SearchResultsTableViewController` is hidden behind the searchbar in the navigation bar.
**FIX**: Convert `SearchResultsTableViewController` into a `UIViewController` with a `UITableView` and set constraints on the table view
- After changing the `From/To` textfield and then selecting a new location, the navigation bar height isn't restored so there is a huge gap right below the navigation bar
**FIX**: Call `setNeedsLayout()` on the `navigationBar.view` after we set the `navigationItem.searchController` so that the `navigationBar`'s height get adjusted appropriately