### PR TITLE
Keep Navigation Bar when Popping from RouteOptionsViewController

### DIFF
--- a/TCAT/Controllers/CustomNavigationController.swift
+++ b/TCAT/Controllers/CustomNavigationController.swift
@@ -132,6 +132,10 @@ class CustomNavigationController: UINavigationController, UINavigationController
 
     // MARK: UINavigationControllerDelegate Functions
 
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        setNavigationBarHidden(viewController is HomeMapViewController, animated: animated)
+    }
+
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         interactivePopGestureRecognizer?.isEnabled = (responds(to: #selector(getter: interactivePopGestureRecognizer)) && viewControllers.count > 1)
     }

--- a/TCAT/Controllers/HomeMapViewController.swift
+++ b/TCAT/Controllers/HomeMapViewController.swift
@@ -70,7 +70,6 @@ class HomeMapViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        navigationController?.isNavigationBarHidden = true
 
         // Add Notification Observers
         NotificationCenter.default.addObserver(self,
@@ -91,7 +90,6 @@ class HomeMapViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        navigationController?.isNavigationBarHidden = false
         reachability?.stopNotifier()
 
         // Remove Notification Observers


### PR DESCRIPTION
Keep the navigation bar when popping from RouteOptionsViewController to HomeMapViewController

Before / After
![Untitled](https://user-images.githubusercontent.com/1882991/65819758-608f9780-e1ee-11e9-9a04-e994dd4e1ac2.png)

Issues:
* The leading edge shadow is not applied to the navigation bar as well. 

