### PR TITLE
Lucy/stop label changes

### DIFF
--- a/TCAT/Views/RouteDiagramSegment.swift
+++ b/TCAT/Views/RouteDiagramSegment.swift
@@ -90,15 +90,12 @@ class RouteDiagramSegment: UIView {
     // MARK: Get data from route ojbect
 
     private func getStopLabel(withName name: String, withStayOnBusForTranfer stayOnBusForTranfer: Bool, withDistance distance: Double?) -> UILabel {
-        let labelPadding: CGFloat = 12
-        let rightPadding: CGFloat = 16
-        let xPos: CGFloat = 101
-        let width: CGFloat = UIScreen.main.bounds.width - xPos - rightPadding - labelPadding
 
         let stopLabel = UILabel()
         // allow for multi-line label for long stop names
         stopLabel.allowsDefaultTighteningForTruncation = true
         stopLabel.lineBreakMode = .byWordWrapping
+        stopLabel.preferredMaxLayoutWidth = 266
         stopLabel.numberOfLines = 0
 
         let stopNameAttrs: [NSAttributedString.Key: Any] = [
@@ -109,20 +106,12 @@ class RouteDiagramSegment: UIView {
 
         if let distance = distance {
 
-            let testStopLabel = getTestStopLabel(withName: name)
-            let testDistanceLabel = getTestDistanceLabel(withDistance: distance)
-
-            var addLinebreak = false
-            if testStopLabel.frame.width + testDistanceLabel.frame.width > width {
-                addLinebreak = true
-            }
-
             let travelDistanceAttrs: [NSAttributedString.Key: Any] = [
                 .font: UIFont.getFont(.regular, size: 12.0),
                 .foregroundColor: Colors.metadataIcon
             ]
 
-            let travelDistance = NSMutableAttributedString(string: addLinebreak ? "\n\(distance.roundedString) away" : " \(distance.roundedString) away", attributes: travelDistanceAttrs)
+            let travelDistance = NSMutableAttributedString(string: " \(distance.roundedString) away", attributes: travelDistanceAttrs)
             stopName.append(travelDistance)
         }
 
@@ -138,25 +127,6 @@ class RouteDiagramSegment: UIView {
         stopLabel.attributedText = stopName
 
         return stopLabel
-    }
-
-    private func getTestStopLabel(withName name: String) -> UILabel {
-        let testStopLabel = UILabel()
-        testStopLabel.font = .getFont(.regular, size: 14.0)
-        testStopLabel.textColor = Colors.primaryText
-        testStopLabel.text = name
-        testStopLabel.sizeToFit()
-        return testStopLabel
-    }
-
-    private func getTestDistanceLabel(withDistance distance: Double) -> UILabel {
-        let testDistanceLabel = UILabel()
-        testDistanceLabel.font = .getFont(.regular, size: 12.0)
-        testDistanceLabel.textColor = Colors.metadataIcon
-        testDistanceLabel.text = " \(distance.roundedString) away"
-        testDistanceLabel.sizeToFit()
-
-        return testDistanceLabel
     }
 
     private func isStopLabelOneLine(_ stopLabel: UILabel) -> Bool {

--- a/TCAT/Views/RouteDiagramSegment.swift
+++ b/TCAT/Views/RouteDiagramSegment.swift
@@ -90,12 +90,17 @@ class RouteDiagramSegment: UIView {
     // MARK: Get data from route ojbect
 
     private func getStopLabel(withName name: String, withStayOnBusForTranfer stayOnBusForTranfer: Bool, withDistance distance: Double?) -> UILabel {
+        
+        let labelPadding: CGFloat = 12
+        let rightPadding: CGFloat = 40
+        let xPos: CGFloat = 96
+        let width: CGFloat = UIScreen.main.bounds.width - xPos - rightPadding - labelPadding
 
         let stopLabel = UILabel()
         // allow for multi-line label for long stop names
         stopLabel.allowsDefaultTighteningForTruncation = true
         stopLabel.lineBreakMode = .byWordWrapping
-        stopLabel.preferredMaxLayoutWidth = 266
+        stopLabel.preferredMaxLayoutWidth = width
         stopLabel.numberOfLines = 0
 
         let stopNameAttrs: [NSAttributedString.Key: Any] = [
@@ -110,8 +115,10 @@ class RouteDiagramSegment: UIView {
                 .font: UIFont.getFont(.regular, size: 12.0),
                 .foregroundColor: Colors.metadataIcon
             ]
+            
+            let addLineBreak = getStopLabelWidth(withName: name, withDistance: distance) > width
 
-            let travelDistance = NSMutableAttributedString(string: " \(distance.roundedString) away", attributes: travelDistanceAttrs)
+            let travelDistance = NSMutableAttributedString(string: addLineBreak ? "\n\(distance.roundedString) away" : " \(distance.roundedString) away", attributes: travelDistanceAttrs)
             stopName.append(travelDistance)
         }
 
@@ -127,6 +134,14 @@ class RouteDiagramSegment: UIView {
         stopLabel.attributedText = stopName
 
         return stopLabel
+    }
+    
+    private func getStopLabelWidth(withName name: String, withDistance distance: Double) -> CGFloat {
+        let testStopLabel = UILabel()
+        testStopLabel.font = .getFont(.regular, size: 14.0)
+        testStopLabel.text = "\(name) \(distance.roundedString) away"
+        testStopLabel.sizeToFit()
+        return testStopLabel.frame.width
     }
 
     private func isStopLabelOneLine(_ stopLabel: UILabel) -> Bool {


### PR DESCRIPTION
Addresses #289 

Initially, PR was to remove the test label functions to compute the width of "test labels" before we add the actual label onto the screen, which was jank and not ideal. After some playing around, I think that we actually need to have the function because without it, we cannot manually add a line break between our stop name and stop distance. 
- So instead of getting rid of the functions completely, I just consolidated the two into a more simplified function that takes into account both stop name and stop distance but doesn't account for miscellaneous style stuff. 
- I also added preferredMaxWidth to make sure text overflow happens
- I fixed the constants we're currently using for max width calculation for our labels

Note: Currently, the app crashes because of a mix of iOS things and live updates so we might wanna hold off on merging this PR?

<img width="509" alt="Screen Shot 2019-09-29 at 1 26 17 PM" src="https://user-images.githubusercontent.com/29307883/65836109-baf72980-e2bc-11e9-9c29-a67cd781c2c1.png">
