### PR TITLE
Lucy/redo live updates

### DIFF
--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -48,7 +48,6 @@ class RouteTableViewCell: UITableViewCell {
         setupDepartureStackView()
         setupTravelTimeLabel()
         setupLiveContainerView()
-        setLiveElements()
 
         setupConstraints()
     }
@@ -161,10 +160,14 @@ class RouteTableViewCell: UITableViewCell {
     }
 
     // MARK: Set Data
-    func configure(for route: Route, delegate: RouteTableViewCellDelegate? = nil) {
+    func configure(for route: Route, delegate: RouteTableViewCellDelegate? = nil, delayState: DelayState? = nil) {
         self.delegate = delegate
 
 //        timer = Timer.scheduledTimer(timeInterval: 5.0, target: self, selector: #selector(updateLiveElementsWithDelay(sender:)), userInfo: ["route": route], repeats: true)
+        
+        if let delay = delayState {
+            setLiveElements(withDelayState: delay)
+        }
 
         setTravelTime(withDepartureTime: route.departureTime, withArrivalTime: route.arrivalTime)
 
@@ -297,9 +300,12 @@ class RouteTableViewCell: UITableViewCell {
     }
 
     // Update all of the live elements based on the delay state.
-    private func setLiveElements() {
+    private func setLiveElements(withDelayState: DelayState) {
         
         if let delayState = delay {
+            
+            print("Yes delay")
+            print(delayState)
             
             switch delayState {
             case .late(date: let delayedDepartureTime):

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -34,7 +34,7 @@ class RouteTableViewCell: UITableViewCell {
     // MARK: Data vars
     private let containerViewLayoutInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 12)
     private let networking: Networking = URLSession.shared.request
-    private var timer: Timer?
+//    private var timer: Timer?
 
     // MARK: Init
 

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -30,11 +30,12 @@ class RouteTableViewCell: UITableViewCell {
     private let liveLabel = UILabel()
     private var routeDiagram: RouteDiagram!
     private let travelTimeLabel = UILabel()
+    
+    var delay: DelayState?
 
     // MARK: Data vars
     private let containerViewLayoutInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 12)
     private let networking: Networking = URLSession.shared.request
-//    private var timer: Timer?
 
     // MARK: Init
 
@@ -47,6 +48,7 @@ class RouteTableViewCell: UITableViewCell {
         setupDepartureStackView()
         setupTravelTimeLabel()
         setupLiveContainerView()
+        setLiveElements()
 
         setupConstraints()
     }
@@ -295,43 +297,45 @@ class RouteTableViewCell: UITableViewCell {
     }
 
     // Update all of the live elements based on the delay state.
-//    private func setLiveElements(withDelayState delayState: DelayState) {
+    private func setLiveElements() {
+        
+        if let delayState = delay {
+            
+            switch delayState {
+            case .late(date: let delayedDepartureTime):
+                liveLabel.textColor = Colors.lateRed
+                liveLabel.text = "Late - \(Time.timeString(from: delayedDepartureTime))"
+                liveIndicatorView.setColor(to: Colors.lateRed)
+                showLiveElements()
 
-//        switch delayState {
-//
-//        case .late(date: let delayedDepartureTime):
-//            liveLabel.textColor = Colors.lateRed
-//            liveLabel.text = "Late - \(Time.timeString(from: delayedDepartureTime))"
-//            liveIndicatorView.setColor(to: Colors.lateRed)
-//            showLiveElements()
+            case .onTime(date: _):
+                liveLabel.textColor = Colors.liveGreen
+                liveLabel.text = "On Time"
+                liveIndicatorView.setColor(to: Colors.liveGreen)
+                showLiveElements()
 
-//        case .onTime(date: _):
-//            liveLabel.textColor = Colors.liveGreen
-//            liveLabel.text = "On Time"
-//            liveIndicatorView.setColor(to: Colors.liveGreen)
-//            showLiveElements()
+            case .noDelay(date: _):
+                hideLiveElements()
+            }
+        }
 
-//        case .noDelay(date: _):
-//            hideLiveElements()
-//        }
-//
-//    }
+    }
 
-//    private func showLiveElements() {
-//        delegate?.updateLiveElements {
-//            liveContainerView.addSubview(liveIndicatorView)
-//            liveContainerView.addSubview(liveLabel)
-//            setLiveIndicatorViewsConstraints()
-//            layoutIfNeeded()
-//        }
-//    }
+    private func showLiveElements() {
+        delegate?.updateLiveElements {
+            liveContainerView.addSubview(liveIndicatorView)
+            liveContainerView.addSubview(liveLabel)
+            setLiveIndicatorViewsConstraints()
+            layoutIfNeeded()
+        }
+    }
 
-//    private func hideLiveElements() {
-//        delegate?.updateLiveElements {
-//            liveLabel.removeFromSuperview()
-//            liveIndicatorView.removeFromSuperview()
-//        }
-//    }
+    private func hideLiveElements() {
+        delegate?.updateLiveElements {
+            liveLabel.removeFromSuperview()
+            liveIndicatorView.removeFromSuperview()
+        }
+    }
     
     // Lucy - Based on the delay state, change the boarding time and also the departure label
     private func setDepartureTime(withStartTime startTime: Date, withDelayState delayState: DelayState) {

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -189,6 +189,9 @@ class RouteTableViewCell: UITableViewCell {
     // MARK: Get Data
 
     private func getDelayState(fromRoute route: Route) -> DelayState {
+        
+        print("Getting delay state")
+        
         if let firstDepartDirection = route.getFirstDepartRawDirection() {
 
             let departTime = firstDepartDirection.startTime

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -11,7 +11,6 @@ import SwiftyJSON
 import UIKit
 
 protocol RouteTableViewCellDelegate: class {
-    func updateLiveElements(fun: () -> Void)
     func getRowNum(for cell: RouteTableViewCell) -> Int?
 }
 
@@ -169,10 +168,6 @@ class RouteTableViewCell: UITableViewCell {
             setLiveElements(withDelayState: delay)
             setDepartureTime(withStartTime: Date(), withDelayState: delay)
         }
-        
-//        if route.isRawWalkingRoute() {
-//            hideLiveElements()
-//        }
 
         /*
          TODO #266: Find fix for updating tableview when delays occur. We currently just update the tableview but because
@@ -308,42 +303,42 @@ class RouteTableViewCell: UITableViewCell {
             liveLabel.textColor = Colors.lateRed
             liveLabel.text = "Late - \(Time.timeString(from: delayedDepartureTime))"
             liveIndicatorView.setColor(to: Colors.lateRed)
-            showLiveElements()
+            liveContainerView.addSubview(liveIndicatorView)
+            liveContainerView.addSubview(liveLabel)
+            setLiveIndicatorViewsConstraints()
 
         case .onTime(date: _):
             liveLabel.textColor = Colors.liveGreen
             liveLabel.text = "On Time"
             liveIndicatorView.setColor(to: Colors.liveGreen)
-            showLiveElements()
-
-        case .noDelay(date: _):
-            hideLiveElements()
-        }
-
-    }
-
-    private func showLiveElements() {
-        liveContainerView.addSubview(liveIndicatorView)
-        liveContainerView.addSubview(liveLabel)
-        setLiveIndicatorViewsConstraints()
-
-        // layoutIfNeeded()
-        delegate?.updateLiveElements {
             liveContainerView.addSubview(liveIndicatorView)
             liveContainerView.addSubview(liveLabel)
             setLiveIndicatorViewsConstraints()
-            // layoutIfNeeded()
-        }
-    }
-        
-    private func hideLiveElements() {
-        delegate?.updateLiveElements {
+
+        case .noDelay(date: _):
             liveLabel.removeFromSuperview()
             liveIndicatorView.removeFromSuperview()
         }
+
     }
+
+//    private func showLiveElements() {
+//        layoutIfNeeded()
+//        delegate?.updateLiveElements {
+//            liveContainerView.addSubview(liveIndicatorView)
+//            liveContainerView.addSubview(liveLabel)
+//            setLiveIndicatorViewsConstraints()
+//            layoutIfNeeded()
+//        }
+//    }
+        
+//    private func hideLiveElements() {
+//        delegate?.updateLiveElements {
+//            liveLabel.removeFromSuperview()
+//            liveIndicatorView.removeFromSuperview()
+//        }
+//    }
     
-    // Lucy - Based on the delay state, change the boarding time and also the departure label
     private func setDepartureTime(withStartTime startTime: Date, withDelayState delayState: DelayState) {
 
         switch delayState {
@@ -386,7 +381,8 @@ class RouteTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         routeDiagram.removeFromSuperview()
         routeDiagram.snp.removeConstraints()
-        hideLiveElements()
+        liveLabel.removeFromSuperview()
+        liveIndicatorView.removeFromSuperview()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -291,11 +291,6 @@ class RouteTableViewCell: UITableViewCell {
 //        }
 //    }
 
-//    private func getDelay(tripId: String, stopId: String) -> Future<Response<Int?>> {
-//        return networking(Endpoint.getDelay(tripID: tripId, stopID: stopId)).decode()
-//    }
-
-    // Update all of the live elements based on the delay state.
     private func setLiveElements(withDelayState delayState: DelayState) {
 
         switch delayState {
@@ -321,23 +316,6 @@ class RouteTableViewCell: UITableViewCell {
         }
 
     }
-
-//    private func showLiveElements() {
-//        layoutIfNeeded()
-//        delegate?.updateLiveElements {
-//            liveContainerView.addSubview(liveIndicatorView)
-//            liveContainerView.addSubview(liveLabel)
-//            setLiveIndicatorViewsConstraints()
-//            layoutIfNeeded()
-//        }
-//    }
-        
-//    private func hideLiveElements() {
-//        delegate?.updateLiveElements {
-//            liveLabel.removeFromSuperview()
-//            liveIndicatorView.removeFromSuperview()
-//        }
-//    }
     
     private func setDepartureTime(withStartTime startTime: Date, withDelayState delayState: DelayState) {
 

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -30,7 +30,7 @@ class RouteTableViewCell: UITableViewCell {
     private let liveLabel = UILabel()
     private var routeDiagram: RouteDiagram!
     private let travelTimeLabel = UILabel()
-    
+
     // MARK: Data vars
     private let containerViewLayoutInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 12)
     private let networking: Networking = URLSession.shared.request
@@ -162,7 +162,7 @@ class RouteTableViewCell: UITableViewCell {
         self.delegate = delegate
 
         setTravelTime(withDepartureTime: route.departureTime, withArrivalTime: route.arrivalTime)
-        
+
         setDepartureTimeAndLiveElements(withRoute: route)
         
         if let delay = delayState {
@@ -170,9 +170,9 @@ class RouteTableViewCell: UITableViewCell {
             setDepartureTime(withStartTime: Date(), withDelayState: delay)
         }
         
-        if route.isRawWalkingRoute() {
-            hideLiveElements()
-        }
+//        if route.isRawWalkingRoute() {
+//            hideLiveElements()
+//        }
 
         /*
          TODO #266: Find fix for updating tableview when delays occur. We currently just update the tableview but because
@@ -199,7 +199,7 @@ class RouteTableViewCell: UITableViewCell {
         if let firstDepartDirection = route.getFirstDepartRawDirection() {
 
             let departTime = firstDepartDirection.startTime
-        
+
             if let delay = firstDepartDirection.delay {
                 let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
                 // Our live tracking only updates once every 30 seconds, so we want to show buses that are delayed by < 120 as on time in order to be more accurate about the status of slightly delayed buses. This way riders get to a bus stop earlier rather than later when trying to catch such buses.
@@ -227,11 +227,11 @@ class RouteTableViewCell: UITableViewCell {
             setDepartureTimeToWalking()
             return
         }
-        else {
-            let delayState = getDelayState(fromRoute: route)
-            setDepartureTime(withStartTime: Date(), withDelayState: delayState)
-            setLiveElements(withDelayState: delayState)
-        }
+
+        let delayState = getDelayState(fromRoute: route)
+        setDepartureTime(withStartTime: Date(), withDelayState: delayState)
+        setLiveElements(withDelayState: delayState)
+
 
     }
     
@@ -302,32 +302,24 @@ class RouteTableViewCell: UITableViewCell {
 
     // Update all of the live elements based on the delay state.
     private func setLiveElements(withDelayState delayState: DelayState) {
-        
+
         switch delayState {
         case .late(date: let delayedDepartureTime):
             liveLabel.textColor = Colors.lateRed
             liveLabel.text = "Late - \(Time.timeString(from: delayedDepartureTime))"
             liveIndicatorView.setColor(to: Colors.lateRed)
-            liveContainerView.addSubview(liveIndicatorView)
-            liveContainerView.addSubview(liveLabel)
-            setLiveIndicatorViewsConstraints()
             showLiveElements()
 
         case .onTime(date: _):
             liveLabel.textColor = Colors.liveGreen
             liveLabel.text = "On Time"
             liveIndicatorView.setColor(to: Colors.liveGreen)
-            liveContainerView.addSubview(liveIndicatorView)
-            liveContainerView.addSubview(liveLabel)
-            setLiveIndicatorViewsConstraints()
             showLiveElements()
 
         case .noDelay(date: _):
-            liveLabel.removeFromSuperview()
-            liveIndicatorView.removeFromSuperview()
             hideLiveElements()
         }
-        
+
     }
 
     private func showLiveElements() {
@@ -335,12 +327,12 @@ class RouteTableViewCell: UITableViewCell {
         liveContainerView.addSubview(liveLabel)
         setLiveIndicatorViewsConstraints()
 
-//        layoutIfNeeded()
+        // layoutIfNeeded()
         delegate?.updateLiveElements {
             liveContainerView.addSubview(liveIndicatorView)
             liveContainerView.addSubview(liveLabel)
             setLiveIndicatorViewsConstraints()
-//            layoutIfNeeded()
+            // layoutIfNeeded()
         }
     }
         
@@ -394,8 +386,7 @@ class RouteTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         routeDiagram.removeFromSuperview()
         routeDiagram.snp.removeConstraints()
-        
-//        hideLiveElements()
+        hideLiveElements()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -10,14 +10,7 @@ import FutureNova
 import SwiftyJSON
 import UIKit
 
-protocol RouteTableViewCellDelegate: class {
-    func getRowNum(for cell: RouteTableViewCell) -> Int?
-}
-
 class RouteTableViewCell: UITableViewCell {
-
-    // MARK: Data vars
-    private weak var delegate: RouteTableViewCellDelegate?
 
     // MARK: View vars
     private let arrowImageView = UIImageView(image: #imageLiteral(resourceName: "side-arrow"))
@@ -157,8 +150,7 @@ class RouteTableViewCell: UITableViewCell {
     }
 
     // MARK: Set Data
-    func configure(for route: Route, delegate: RouteTableViewCellDelegate? = nil, delayState: DelayState? = nil) {
-        self.delegate = delegate
+    func configure(for route: Route, delayState: DelayState? = nil) {
 
         setTravelTime(withDepartureTime: route.departureTime, withArrivalTime: route.arrivalTime)
 
@@ -227,69 +219,7 @@ class RouteTableViewCell: UITableViewCell {
         setDepartureTime(withStartTime: Date(), withDelayState: delayState)
         setLiveElements(withDelayState: delayState)
 
-
     }
-    
-    // Note for Lucy: "route.getFirstDepartRawDirection()?.delay = delay" missing!
-
-//    @objc private func updateLiveElementsWithDelay(sender: Timer) {
-//        guard let userInfo = sender.userInfo as? [String: Route],
-//            let route = userInfo["route"] else { return }
-//
-//        if !route.isRawWalkingRoute(),
-//            let direction = route.getFirstDepartRawDirection(),
-//            let tripId = direction.tripIdentifiers?.first,
-//            let stopId = direction.stops.first?.id {
-//
-//            getDelay(tripId: tripId, stopId: stopId).observe(with: { [weak self] result in
-//                guard let `self` = self else { return }
-//                let fileName = "RouteTableViewCell"
-//                DispatchQueue.main.async {
-//                    switch result {
-//                    case .value (let delayResponse):
-//                        guard (delayResponse.data != nil), let delay = delayResponse.data else {
-//                            self.setDepartureTimeAndLiveElements(withRoute: route)
-//                            return
-//                        }
-//
-//                        let isNewDelayValue = (route.getFirstDepartRawDirection()?.delay != delay)
-//                        if isNewDelayValue {
-//                            JSONFileManager.shared.logDelayParemeters(timestamp: Date(), stopId: stopId, tripId: tripId)
-//                            JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: tripId, stopId: stopId))
-//                            if let data = try? JSONEncoder().encode(delayResponse) {
-//                                do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: self.delegate?.getRowNum(for: self) ?? -1)) } catch let error {
-//                                    let line = "\(fileName) \(#function): \(error.localizedDescription)"
-//                                    print(line)
-//                                }
-//                            }
-//                        }
-//
-//                        let departTime = direction.startTime
-//                        let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
-//
-//                        let isLateDelay = (Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending)
-//                        if isLateDelay {
-//                            let delayState = DelayState.late(date: delayedDepartTime)
-//                            self.setDepartureTime(withStartTime: Date(), withDelayState: delayState)
-//                            self.setLiveElements(withDelayState: delayState)
-//                        } else {
-//                            let delayState = DelayState.onTime(date: departTime)
-//                            self.setDepartureTime(withStartTime: Date(), withDelayState: delayState)
-//                            self.setLiveElements(withDelayState: delayState)
-//                        }
-//
-//                        route.getFirstDepartRawDirection()?.delay = delay
-//
-//                    case .error(let error):
-//                        print("\(fileName) \(#function) error: \(error.localizedDescription)")
-//                        self.setDepartureTimeAndLiveElements(withRoute: route)
-//                    }
-//                }
-//            })
-//        } else {
-//            setDepartureTimeAndLiveElements(withRoute: route)
-//        }
-//    }
 
     private func setLiveElements(withDelayState delayState: DelayState) {
 

--- a/TCAT/Cells/RouteTableViewCell.swift
+++ b/TCAT/Cells/RouteTableViewCell.swift
@@ -182,7 +182,6 @@ class RouteTableViewCell: UITableViewCell {
     // MARK: Get Data
 
     private func getDelayState(fromRoute route: Route) -> DelayState {
-
         if let firstDepartDirection = route.getFirstDepartRawDirection() {
 
             let departTime = firstDepartDirection.startTime
@@ -207,7 +206,6 @@ class RouteTableViewCell: UITableViewCell {
     }
 
     private func setDepartureTimeAndLiveElements(withRoute route: Route) {
-        
         let isWalkingRoute = route.isRawWalkingRoute()
 
         if isWalkingRoute {

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -214,10 +214,8 @@ extension RouteOptionsViewController: UITableViewDataSource {
         if let delay = delayDictionary[id] {
             cell.delay = delay
         }
-        
-        print("configure")
-        
-        cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self)
+            
+        cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self, delayState: delayDictionary[id] )
 
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -209,14 +209,11 @@ extension RouteOptionsViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.Cells.routeOptionsCellIdentifier, for: indexPath) as? RouteTableViewCell
             else { return UITableViewCell() }
         
-        let id = routes[indexPath.section][indexPath.row].routeId
+        let route_id = routes[indexPath.section][indexPath.row].routeId
+        print("Route ID: \(route_id)")
         
-        if let delay = delayDictionary[id] {
-            cell.delay = delay
-        }
-            
-        cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self, delayState: delayDictionary[id] )
-
+        cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self)
+        
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))
         cell.addGestureRecognizer(longPressGestureRecognizer)

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -400,10 +400,6 @@ extension RouteOptionsViewController: RouteTableViewCellDelegate {
     func getRowNum(for cell: RouteTableViewCell) -> Int? {
         return routeResults.indexPath(for: cell)?.row
     }
-
-    func updateLiveElements(fun: () -> Void) {
-        routeResults.performBatchUpdates({fun()}, completion: nil)
-    }
 }
 
 extension RouteOptionsViewController: RouteSelectionViewDelegate {

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -208,7 +208,15 @@ extension RouteOptionsViewController: UITableViewDataSource {
 
         guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.Cells.routeOptionsCellIdentifier, for: indexPath) as? RouteTableViewCell
             else { return UITableViewCell() }
-
+        
+        let id = routes[indexPath.section][indexPath.row].routeId
+        
+        if let delay = delayDictionary[id] {
+            cell.delay = delay
+        }
+        
+        print("configure")
+        
         cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self)
 
         // Add share action for long press gestures on non 3D Touch devices

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -211,7 +211,7 @@ extension RouteOptionsViewController: UITableViewDataSource {
         
         let route_id = routes[indexPath.section][indexPath.row].routeId
         
-        cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self, delayState: delayDictionary[route_id])
+        cell.configure(for: routes[indexPath.section][indexPath.row], delayState: delayDictionary[route_id])
         
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))
@@ -393,13 +393,6 @@ extension RouteOptionsViewController: DZNEmptyDataSetSource, DZNEmptyDataSetDele
 // Helper function inserted by Swift 4.2 migrator.
 private func convertToUIApplicationOpenExternalURLOptionsKeyDictionary(_ input: [String: Any]) -> [UIApplication.OpenExternalURLOptionsKey: Any] {
     return Dictionary(uniqueKeysWithValues: input.map { key, value in (UIApplication.OpenExternalURLOptionsKey(rawValue: key), value)})
-}
-
-extension RouteOptionsViewController: RouteTableViewCellDelegate {
-
-    func getRowNum(for cell: RouteTableViewCell) -> Int? {
-        return routeResults.indexPath(for: cell)?.row
-    }
 }
 
 extension RouteOptionsViewController: RouteSelectionViewDelegate {

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -210,9 +210,9 @@ extension RouteOptionsViewController: UITableViewDataSource {
             else { return UITableViewCell() }
         
         let route_id = routes[indexPath.section][indexPath.row].routeId
-        print("Route ID: \(route_id)")
+//        print("Route ID: \(route_id)")
         
-        cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self)
+        cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self, delayState: delayDictionary[route_id])
         
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))
@@ -403,9 +403,7 @@ extension RouteOptionsViewController: RouteTableViewCellDelegate {
     }
 
     func updateLiveElements(fun: () -> Void) {
-        routeResults.beginUpdates()
-        fun()
-        routeResults.endUpdates()
+        routeResults.performBatchUpdates({fun()}, completion: nil)
     }
 }
 

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -209,9 +209,9 @@ extension RouteOptionsViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.Cells.routeOptionsCellIdentifier, for: indexPath) as? RouteTableViewCell
             else { return UITableViewCell() }
         
-        let route_id = routes[indexPath.section][indexPath.row].routeId
+        let routeId = routes[indexPath.section][indexPath.row].routeId
         
-        cell.configure(for: routes[indexPath.section][indexPath.row], delayState: delayDictionary[route_id])
+        cell.configure(for: routes[indexPath.section][indexPath.row], delayState: delayDictionary[routeId])
         
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -209,9 +209,8 @@ extension RouteOptionsViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.Cells.routeOptionsCellIdentifier, for: indexPath) as? RouteTableViewCell
             else { return UITableViewCell() }
         
-        let routeId = routes[indexPath.section][indexPath.row].routeId
-        
-        cell.configure(for: routes[indexPath.section][indexPath.row], delayState: delayDictionary[routeId])
+        let route = routes[indexPath.section][indexPath.row]
+        cell.configure(for: route, delayState: delayDictionary[route.routeId])
         
         // Add share action for long press gestures on non 3D Touch devices
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -210,7 +210,6 @@ extension RouteOptionsViewController: UITableViewDataSource {
             else { return UITableViewCell() }
         
         let route_id = routes[indexPath.section][indexPath.row].routeId
-//        print("Route ID: \(route_id)")
         
         cell.configure(for: routes[indexPath.section][indexPath.row], delegate: self, delayState: delayDictionary[route_id])
         

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -42,7 +42,7 @@ class RouteOptionsViewController: UIViewController {
     var currentLocation: CLLocationCoordinate2D?
     var lastRouteRefreshDate = Date()
     var locationManager: CLLocationManager!
-    var routes: [[Route]] = [] // Lucy - Array of all the routes
+    var routes: [[Route]] = []
     var searchFrom: Place?
     var searchTime: Date?
     var searchTimeType: SearchType = .leaveNow
@@ -59,11 +59,12 @@ class RouteOptionsViewController: UIViewController {
     private let networking: Networking = URLSession.shared.request
     private let reachability: Reachability? = Reachability(hostname: Endpoint.config.host ?? "")
     private let routeResultsTitle: String = Constants.Titles.routeResults
-
+    
+    // Timer for route live tracking
+    private var routeTimer: Timer?
+    
     /// Returns routes from each section in order
     private var allRoutes: [Route] {
-        print(routes)
-        print("Getting all the routes")
         return routes.flatMap { $0 }
     }
 
@@ -107,6 +108,8 @@ class RouteOptionsViewController: UIViewController {
         }
 
         searchForRoutes()
+        
+        routeTimer = Timer.scheduledTimer(timeInterval: 5.0, target: self, selector: #selector(updateLiveTracking), userInfo: nil, repeats: true)
 
         // Check for 3D Touch availability
         if traitCollection.forceTouchCapability == .available {
@@ -120,9 +123,9 @@ class RouteOptionsViewController: UIViewController {
         super.viewWillAppear(animated)
         setupReachability()
         // Reload data to activate timers again
-        if !routes.isEmpty {
-            routeResults.reloadData()
-        }
+//        if !routes.isEmpty {
+//            routeResults.reloadData()
+//        }
 
         setUpRouteRefreshing()
     }
@@ -323,6 +326,11 @@ class RouteOptionsViewController: UIViewController {
         searchBarView.searchController?.isActive = true
     }
 
+    @objc func updateLiveTracking() {
+        print(routes)
+        print("Update Live Tracking")
+    }
+    
     @objc private func refreshRoutesAndTime() {
         let now = Date()
         if let leaveDate = searchTime,

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -60,10 +60,11 @@ class RouteOptionsViewController: UIViewController {
     private let reachability: Reachability? = Reachability(hostname: Endpoint.config.host ?? "")
     private let routeResultsTitle: String = Constants.Titles.routeResults
     
-    // Timer for route live tracking
+    // Timer for route live tracking and cell updates
     private var routeTimer: Timer?
     private var updateTimer: Timer?
     
+    // Dictionary to map delays to a route
     var delayDictionary: [String: DelayState] = [:]
     
     /// Returns routes from each section in order
@@ -126,11 +127,6 @@ class RouteOptionsViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupReachability()
-        // Reload data to activate timers again
-//        if !routes.isEmpty {
-//            routeResults.reloadData()
-//        }
-
         setUpRouteRefreshing()
     }
 
@@ -142,12 +138,8 @@ class RouteOptionsViewController: UIViewController {
         // Remove banner
         banner?.dismiss()
         banner = nil
-        // Deactivate and remove timers
-//        routeResults.visibleCells.forEach {
-//            if let cell = $0 as? RouteTableViewCell {
-//                cell.invalidateTimer()
-//            }
-//        }
+        routeTimer?.invalidate()
+        updateTimer?.invalidate()
         // Stop observing when app becomes active 
         NotificationCenter.default.removeObserver(self)
     }
@@ -331,6 +323,7 @@ class RouteOptionsViewController: UIViewController {
     }
     
     @objc func rerenderLiveTracking(sender: Timer) {
+        // Reload table every time update timer is fired
         routeResults.reloadData()
     }
     
@@ -362,8 +355,8 @@ class RouteOptionsViewController: UIViewController {
                                     let delayState = DelayState.onTime(date: departTime)
                                     self.delayDictionary[route.routeId] = delayState
                                 }
-//                                route.getFirstDepartRawDirection()?.delay = delay
-                            
+                                route.getFirstDepartRawDirection()?.delay = delay // what does this actually do?
+
                             case .error(let error):
                                 print(error)
                             }

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -333,17 +333,30 @@ class RouteOptionsViewController: UIViewController {
 
     @objc func updateLiveTracking(sender: Timer) {
         for routesArray in routes {
-            for route in routesArray {
+            for (index, route) in routesArray.enumerated() {
                 if !route.isRawWalkingRoute(),
                     let direction = route.getFirstDepartRawDirection(),
                     let tripId = direction.tripIdentifiers?.first,
                     let stopId = direction.stops.first?.id {
                     getDelay(tripId: tripId, stopId: stopId).observe(with: { result in
+                        let fileName = "RouteTableViewCell"
                         DispatchQueue.main.async {
                             switch result {
                             case .value (let delayResponse):
                                 guard (delayResponse.data != nil), let delay = delayResponse.data else {
                                     return
+                                }
+                                // LUCY - Check
+                                let isNewDelayValue = (route.getFirstDepartRawDirection()?.delay != delay)
+                                if isNewDelayValue {
+                                    JSONFileManager.shared.logDelayParemeters(timestamp: Date(), stopId: stopId, tripId: tripId)
+                                    JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: tripId, stopId: stopId))
+                                    if let data = try? JSONEncoder().encode(delayResponse) {
+                                        do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: index)) } catch let error {
+                                            let line = "\(fileName) \(#function): \(error.localizedDescription)"
+                                            print(line)
+                                        }
+                                    }
                                 }
                                 let departTime = direction.startTime
                                 let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
@@ -355,8 +368,7 @@ class RouteOptionsViewController: UIViewController {
                                     let delayState = DelayState.onTime(date: departTime)
                                     self.delayDictionary[route.routeId] = delayState
                                 }
-                                // LUCY - Check what this does.
-                                route.getFirstDepartRawDirection()?.delay = delay
+                                route.getFirstDepartRawDirection()?.delay = delay // LUCY - Check
 
                             case .error(let error):
                                 print(error)

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -42,7 +42,7 @@ class RouteOptionsViewController: UIViewController {
     var currentLocation: CLLocationCoordinate2D?
     var lastRouteRefreshDate = Date()
     var locationManager: CLLocationManager!
-    var routes: [[Route]] = []
+    var routes: [[Route]] = [] // Lucy - Array of all the routes
     var searchFrom: Place?
     var searchTime: Date?
     var searchTimeType: SearchType = .leaveNow

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -348,7 +348,7 @@ class RouteOptionsViewController: UIViewController {
                     DispatchQueue.main.async {
                         switch result {
                         case .value (let delayResponse):
-                            guard (delayResponse.data != nil), let delay = delayResponse.data else {
+                            guard delayResponse.data != nil, let delay = delayResponse.data else {
                                 return
                             }
                             let isNewDelayValue = route.getFirstDepartRawDirection()?.delay != delay
@@ -365,7 +365,7 @@ class RouteOptionsViewController: UIViewController {
                             let departTime = direction.startTime
                             let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
                             var delayState: DelayState!
-                            let isLateDelay = (Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending)
+                            let isLateDelay = Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending
                             if isLateDelay {
                                 delayState = DelayState.late(date: delayedDepartTime)
                             } else {

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -355,7 +355,8 @@ class RouteOptionsViewController: UIViewController {
                                     let delayState = DelayState.onTime(date: departTime)
                                     self.delayDictionary[route.routeId] = delayState
                                 }
-                                route.getFirstDepartRawDirection()?.delay = delay // what does this actually do?
+                                // LUCY - Check what this does.
+                                route.getFirstDepartRawDirection()?.delay = delay
 
                             case .error(let error):
                                 print(error)

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -331,6 +331,7 @@ class RouteOptionsViewController: UIViewController {
     }
     
     @objc func rerenderLiveTracking(sender: Timer) {
+        print(dump(delayDictionary))
         routeResults.reloadData()
     }
     

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -62,6 +62,8 @@ class RouteOptionsViewController: UIViewController {
 
     /// Returns routes from each section in order
     private var allRoutes: [Route] {
+        print(routes)
+        print("Getting all the routes")
         return routes.flatMap { $0 }
     }
 
@@ -134,11 +136,11 @@ class RouteOptionsViewController: UIViewController {
         banner?.dismiss()
         banner = nil
         // Deactivate and remove timers
-        routeResults.visibleCells.forEach {
-            if let cell = $0 as? RouteTableViewCell {
-                cell.invalidateTimer()
-            }
-        }
+//        routeResults.visibleCells.forEach {
+//            if let cell = $0 as? RouteTableViewCell {
+//                cell.invalidateTimer()
+//            }
+//        }
         // Stop observing when app becomes active 
         NotificationCenter.default.removeObserver(self)
     }
@@ -417,6 +419,10 @@ class RouteOptionsViewController: UIViewController {
                 })
             }
         }
+    }
+    
+    func updateRoutes() {
+        print(routes)
     }
 
     private func getRoutes(start: Place,

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -365,26 +365,12 @@ class RouteOptionsViewController: UIViewController {
                                 let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
                                 let isLateDelay = (Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending)
                                 if isLateDelay {
-                                    print("late")
-                                    print(delay)
-                                    print(route.arrivalTime)
                                     let delayState = DelayState.late(date: delayedDepartTime)
                                     self.delayDictionary[route.routeId] = delayState
                                 } else {
-                                    print("on time")
-                                    print(delay)
-                                    print(route.arrivalTime)
                                     let delayState = DelayState.onTime(date: departTime)
                                     self.delayDictionary[route.routeId] = delayState
                                 }
-//                                if delay > 0 {
-//                                    let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
-//                                    let delayState = DelayState.late(date: delayedDepartTime)
-//                                    self.delayDictionary[route.routeId] = delayState
-//                                } else {
-//                                    let delayState = DelayState.onTime(date: departTime)
-//                                    self.delayDictionary[route.routeId] = delayState
-//                                }
                                 route.getFirstDepartRawDirection()?.delay = delay // LUCY - Check
 
                             case .error(let error):

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -331,7 +331,6 @@ class RouteOptionsViewController: UIViewController {
     }
     
     @objc func rerenderLiveTracking(sender: Timer) {
-        print(dump(delayDictionary))
         routeResults.reloadData()
     }
     
@@ -358,11 +357,9 @@ class RouteOptionsViewController: UIViewController {
                                 let isLateDelay = (Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending)
                                 if isLateDelay {
                                     let delayState = DelayState.late(date: delayedDepartTime)
-//                                    print("isLateDelay for route \(route.routeId) \(delayState)")
                                     self.delayDictionary[route.routeId] = delayState
                                 } else {
                                     let delayState = DelayState.onTime(date: departTime)
-//                                    print("not isLateDelay for route \(route.routeId) \(route.routeId)\(delayState)")
                                     self.delayDictionary[route.routeId] = delayState
                                 }
 //                                route.getFirstDepartRawDirection()?.delay = delay
@@ -473,10 +470,6 @@ class RouteOptionsViewController: UIViewController {
                 })
             }
         }
-    }
-    
-    func updateRoutes() {
-        print(routes)
     }
 
     private func getRoutes(start: Place,

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -332,10 +332,13 @@ class RouteOptionsViewController: UIViewController {
     }
 
     @objc func updateLiveTracking(sender: Timer) {
+        // For each route in each route array inside of the 'routes' array,
+        // retrieve its delay. Use index of route to save delay for route to
+        // JSON file.
         for routesArray in routes {
             for (index, route) in routesArray.enumerated() {
-                if !route.isRawWalkingRoute(),
-                    let direction = route.getFirstDepartRawDirection(),
+                if route.isRawWalkingRoute() {return}
+                if  let direction = route.getFirstDepartRawDirection(),
                     let tripId = direction.tripIdentifiers?.first,
                     let stopId = direction.stops.first?.id {
                     getDelay(tripId: tripId, stopId: stopId).observe(with: { result in
@@ -347,7 +350,7 @@ class RouteOptionsViewController: UIViewController {
                                     return
                                 }
                                 // LUCY - Check
-                                let isNewDelayValue = (route.getFirstDepartRawDirection()?.delay != delay)
+                                let isNewDelayValue = route.getFirstDepartRawDirection()?.delay != delay
                                 if isNewDelayValue {
                                     JSONFileManager.shared.logDelayParemeters(timestamp: Date(), stopId: stopId, tripId: tripId)
                                     JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: tripId, stopId: stopId))
@@ -362,12 +365,26 @@ class RouteOptionsViewController: UIViewController {
                                 let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
                                 let isLateDelay = (Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending)
                                 if isLateDelay {
+                                    print("late")
+                                    print(delay)
+                                    print(route.arrivalTime)
                                     let delayState = DelayState.late(date: delayedDepartTime)
                                     self.delayDictionary[route.routeId] = delayState
                                 } else {
+                                    print("on time")
+                                    print(delay)
+                                    print(route.arrivalTime)
                                     let delayState = DelayState.onTime(date: departTime)
                                     self.delayDictionary[route.routeId] = delayState
                                 }
+//                                if delay > 0 {
+//                                    let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
+//                                    let delayState = DelayState.late(date: delayedDepartTime)
+//                                    self.delayDictionary[route.routeId] = delayState
+//                                } else {
+//                                    let delayState = DelayState.onTime(date: departTime)
+//                                    self.delayDictionary[route.routeId] = delayState
+//                                }
                                 route.getFirstDepartRawDirection()?.delay = delay // LUCY - Check
 
                             case .error(let error):


### PR DESCRIPTION
Addresses issues #316, #286, #285 
-  Moved out the live tracking logic from RouteTableViewCell into RouteOptionsViewController so that it can handle the retrieval of all live tracking for all cells and update the table together at once. 
- This solves our issue of app crashing, live labels showing up on walking routes, and live labels flickering.

Notes:
- Please pull down branch and double check that things do not break! I have done the scrolling around to make sure that app doesn't crash and I have also double checked that the routes I return are the same as the ones the production Transit returns.
- Please also take a look at the "JSONFileManager" stuff because I didn't really know what its doing / how to use it so I just adopted for my needs but I don't know how to test that its working as it should.
- Alanna has put up a new endpoint for all routes delays, which I can adapt to this one or we can try to push this one out first to address the crashing bugs? 