### PR TITLE
Daniel/favorites update

### DIFF
--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -10,6 +10,11 @@ import UIKit
 import DZNEmptyDataSet
 import FutureNova
 
+protocol FavoritesSelectionDelegate: class {
+    /** Indicates to `HomeMapViewController` that it should reload its table. */
+    func didAddNewFavorite()
+}
+
 class FavoritesTableViewController: UIViewController {
 
     private var searchBar = UISearchBar()
@@ -174,9 +179,4 @@ extension FavoritesTableViewController: UISearchBarDelegate {
         }
     }
 
-}
-
-protocol FavoritesSelectionDelegate: class {
-    /** Indicates to `HomeMapViewController` that it should reload its table. */
-    func didAddNewFavorite()
 }

--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -22,7 +22,9 @@ class FavoritesTableViewController: UIViewController {
             tableView.reloadData()
         }
     }
-
+    
+    weak var selectionDelegate: FavoritesSelectionDelegate?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -118,6 +120,7 @@ extension FavoritesTableViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
         if let place = resultsSection.getItem(at: indexPath.row) {
             Global.shared.insertPlace(for: Constants.UserDefaults.favorites, place: place, bottom: true)
+            selectionDelegate?.didAddNewFavorite()
             dismissVC()
         }
     }
@@ -171,4 +174,9 @@ extension FavoritesTableViewController: UISearchBarDelegate {
         }
     }
 
+}
+
+protocol FavoritesSelectionDelegate: class {
+    /** Indicates to `HomeMapViewController` that it should reload its table. */
+    func didAddNewFavorite()
 }

--- a/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
@@ -284,6 +284,5 @@ extension HomeOptionsCardViewController: UITableViewDelegate {
 extension HomeOptionsCardViewController: FavoritesSelectionDelegate {
     func didAddNewFavorite() {
         updatePlaces()
-//        tableView.reloadData()
     }
 }

--- a/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
@@ -280,3 +280,10 @@ extension HomeOptionsCardViewController: UITableViewDelegate {
         }
     }
 }
+
+extension HomeOptionsCardViewController: FavoritesSelectionDelegate {
+    func didAddNewFavorite() {
+        updatePlaces()
+//        tableView.reloadData()
+    }
+}

--- a/TCAT/Controllers/HomeOptionsCardViewController.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController.swift
@@ -263,6 +263,7 @@ class HomeOptionsCardViewController: UIViewController {
 
     @objc func presentFavoritesTVC(sender: UIButton? = nil) {
         let favoritesTVC = FavoritesTableViewController()
+        favoritesTVC.selectionDelegate = self
         let navController = CustomNavigationController(rootViewController: favoritesTVC)
         present(navController, animated: true, completion: nil)
     }


### PR DESCRIPTION
Solution to issue #318:

Defines a `FavoritesSelectionDelegate` at the bottom of `FavoritesTableViewController.swift`. 

`FavoritesTableViewController` has a delegate variable that `HomeOptionsCardViewController` sets to itself. On new favorite selection, the delegate method is called and `HomeOptionsCardVC` calls `updatePlaces()`, which reloads favorites and the table view.