### PR TITLE
Lucy/new delays endpoint

### DIFF
--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -375,65 +375,11 @@ class RouteOptionsViewController: UIViewController {
                             route.getFirstDepartRawDirection()?.delay = delay
                         }
                     case .error(let error):
-                        print(error)
+                        self.printClass(context: "\(#function) error", message: error.localizedDescription)
                     }
                 }
             })
     }
-
-//    @objc func updateLiveTracking(sender: Timer) {
-        // For each route in each route array inside of the 'routes' array,
-        // retrieve its delay. Use index of route to save delay for route to
-        // JSON file.
-//        updateAllRoutesLiveTracking()
-//        for routesArray in routes {
-//            for (index, route) in routesArray.enumerated() {
-//                if !route.isRawWalkingRoute() {
-//                    guard let direction = route.getFirstDepartRawDirection(),
-//                        let tripId = direction.tripIdentifiers?.first,
-//                        let stopId = direction.stops.first?.id else {
-//                            return
-//                    }
-//                    getDelay(tripId: tripId, stopId: stopId).observe(with: { result in
-//                        let fileName = "RouteTableViewCell"
-//                        DispatchQueue.main.async {
-//                            switch result {
-//                            case .value (let delayResponse):
-//                                guard delayResponse.data != nil, let delay = delayResponse.data else {
-//                                    return
-//                                }
-//                                let isNewDelayValue = route.getFirstDepartRawDirection()?.delay != delay
-//                                if isNewDelayValue {
-//                                    JSONFileManager.shared.logDelayParemeters(timestamp: Date(), stopId: stopId, tripId: tripId)
-//                                    JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: tripId, stopId: stopId))
-//                                    if let data = try? JSONEncoder().encode(delayResponse) {
-//                                        do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: index)) } catch let error {
-//                                            let line = "\(fileName) \(#function): \(error.localizedDescription)"
-//                                            print(line)
-//                                        }
-//                                    }
-//                                }
-//                                let departTime = direction.startTime
-//                                let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delay))
-//                                var delayState: DelayState!
-//                                let isLateDelay = Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending
-//                                if isLateDelay {
-//                                    delayState = DelayState.late(date: delayedDepartTime)
-//                                } else {
-//                                    delayState = DelayState.onTime(date: departTime)
-//                                }
-//                                self.delayDictionary[route.routeId] = delayState
-//                                route.getFirstDepartRawDirection()?.delay = delay
-//
-//                            case .error (let error):
-//                                print(error)
-//                            }
-//                        }
-//                    })
-//                }
-//            }
-//        }
-//    }
     
     @objc private func refreshRoutesAndTime() {
         let now = Date()

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -343,7 +343,7 @@ class RouteOptionsViewController: UIViewController {
     @objc func updateAllRoutesLiveTracking() {
         var trips: [Trip] = []
         for routesArray in routes {
-            for (index, route) in routesArray.enumerated() {
+            for route in routesArray {
                 if !route.isRawWalkingRoute() {
                     guard let direction = route.getFirstDepartRawDirection(),
                         let tripId = direction.tripIdentifiers?.first,

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -561,16 +561,15 @@ class RouteOptionsViewController: UIViewController {
         // tripId and stopId to create trip array for request to get all delays.
         for routesArray in routes {
             for route in routesArray {
-                if !route.isRawWalkingRoute() {
-                    guard let direction = route.getFirstDepartRawDirection(),
-                        let tripId = direction.tripIdentifiers?.first,
-                        let stopId = direction.stops.first?.id else {
-                            return
-                    }
-                    tripDictionary[tripId] = route
-                    let trip = Trip(stopID: stopId, tripID: tripId)
-                    trips.append(trip)
+                guard (!route.isRawWalkingRoute()) else { continue }
+                guard let direction = route.getFirstDepartRawDirection(),
+                    let tripId = direction.tripIdentifiers?.first,
+                    let stopId = direction.stops.first?.id else {
+                        continue
                 }
+                tripDictionary[tripId] = route
+                let trip = Trip(stopID: stopId, tripID: tripId)
+                trips.append(trip)
             }
         }
     }

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -360,6 +360,7 @@ class RouteOptionsViewController: UIViewController {
                         for delay in allDelays {
                             let tripRoute = self.tripDictionary[delay.tripID]
                             guard let route = tripRoute,
+                                let routeId = tripRoute?.routeId,
                                 let direction = route.getFirstDepartRawDirection(),
                                 let delayValue = delay.delay else {
                                     return
@@ -368,10 +369,10 @@ class RouteOptionsViewController: UIViewController {
                             let fileName = "RouteTableViewCell"
                             let isNewDelayValue = route.getFirstDepartRawDirection()?.delay != delayValue
                             if isNewDelayValue {
-                                JSONFileManager.shared.logDelayParemeters(timestamp: Date(), stopId: delay.stopID, tripId: delay.tripID)
+                                JSONFileManager.shared.logDelayParameters(timestamp: Date(), stopId: delay.stopID, tripId: delay.tripID)
                                 JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: delay.tripID, stopId: delay.stopID))
                                 if let data = try? JSONEncoder().encode(delay) {
-                                    do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: -1)) } catch let error {
+                                    do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(routeId: routeId)) } catch let error {
                                         let line = "\(fileName) \(#function): \(error.localizedDescription)"
                                         print(line)
                                     }
@@ -386,7 +387,7 @@ class RouteOptionsViewController: UIViewController {
                             } else {
                                 delayState = DelayState.onTime(date: departTime)
                             }
-                            self.delayDictionary[route.routeId] = delayState
+                            self.delayDictionary[routeId] = delayState
                             route.getFirstDepartRawDirection()?.delay = delayValue
                         }
                     case .error(let error):

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -358,26 +358,27 @@ class RouteOptionsViewController: UIViewController {
                         if !delaysResponse.success { return }
                         let allDelays = delaysResponse.data
                         for delay in allDelays {
-                            // let fileName = "RouteTableViewCell"
-//                            let isNewDelayValue = route.getFirstDepartRawDirection()?.delay != delay
-//                            if isNewDelayValue {
-//                                JSONFileManager.shared.logDelayParemeters(timestamp: Date(), stopId: stopId, tripId: tripId)
-//                                JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: tripId, stopId: stopId))
-//                                if let data = try? JSONEncoder().encode(delayResponse) {
-//                                    do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: index)) } catch let error {
-//                                        let line = "\(fileName) \(#function): \(error.localizedDescription)"
-//                                        print(line)
-//                                    }
-//                                }
-//                            }
                             let tripRoute = self.tripDictionary[delay.tripID]
                             guard let route = tripRoute,
                                 let direction = route.getFirstDepartRawDirection(),
-                                let delayVal = delay.delay else {
+                                let delayValue = delay.delay else {
                                     return
                             }
+                            // LUCY - Double Check JSON File outputs
+                            let fileName = "RouteTableViewCell"
+                            let isNewDelayValue = route.getFirstDepartRawDirection()?.delay != delayValue
+                            if isNewDelayValue {
+                                JSONFileManager.shared.logDelayParemeters(timestamp: Date(), stopId: delay.stopID, tripId: delay.tripID)
+                                JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: delay.tripID, stopId: delay.stopID))
+                                if let data = try? JSONEncoder().encode(delay) {
+                                    do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: -1)) } catch let error {
+                                        let line = "\(fileName) \(#function): \(error.localizedDescription)"
+                                        print(line)
+                                    }
+                                }
+                            }
                             let departTime = direction.startTime
-                            let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delayVal))
+                            let delayedDepartTime = departTime.addingTimeInterval(TimeInterval(delayValue))
                             var delayState: DelayState!
                             let isLateDelay = Time.compare(date1: delayedDepartTime, date2: departTime) == .orderedDescending
                             if isLateDelay {
@@ -386,7 +387,7 @@ class RouteOptionsViewController: UIViewController {
                                 delayState = DelayState.onTime(date: departTime)
                             }
                             self.delayDictionary[route.routeId] = delayState
-                            route.getFirstDepartRawDirection()?.delay = delayVal
+                            route.getFirstDepartRawDirection()?.delay = delayValue
                         }
                     case .error(let error):
                         print(error)

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -561,8 +561,8 @@ class RouteOptionsViewController: UIViewController {
         // tripId and stopId to create trip array for request to get all delays.
         for routesArray in routes {
             for route in routesArray {
-                guard (!route.isRawWalkingRoute()) else { continue }
-                guard let direction = route.getFirstDepartRawDirection(),
+                guard !route.isRawWalkingRoute(),
+                    let direction = route.getFirstDepartRawDirection(),
                     let tripId = direction.tripIdentifiers?.first,
                     let stopId = direction.stops.first?.id else {
                         continue

--- a/TCAT/Network/Endpoints.swift
+++ b/TCAT/Network/Endpoints.swift
@@ -117,13 +117,11 @@ extension Endpoint {
         }
 
         let body = GetBusLocationsBody(data: locationsInfo)
-        print(body)
         return Endpoint(path: Constants.Endpoints.busLocations, body: body)
     }
 
     static func getDelay(tripID: String, stopID: String) -> Endpoint {
         let queryItems = GetDelayBody(stopID: stopID, tripID: tripID).toQueryItems()
-        print(queryItems)
         return Endpoint(path: Constants.Endpoints.delay, queryItems: queryItems)
     }
     

--- a/TCAT/Network/Endpoints.swift
+++ b/TCAT/Network/Endpoints.swift
@@ -127,7 +127,6 @@ extension Endpoint {
     
     static func getAllDelays(trips: [Trip]) -> Endpoint {
         let body = TripBody(data: trips)
-        print(body)
         return Endpoint(path: Constants.Endpoints.delays, body: body)
     }
     

--- a/TCAT/Network/Endpoints.swift
+++ b/TCAT/Network/Endpoints.swift
@@ -117,14 +117,22 @@ extension Endpoint {
         }
 
         let body = GetBusLocationsBody(data: locationsInfo)
+        print(body)
         return Endpoint(path: Constants.Endpoints.busLocations, body: body)
     }
 
     static func getDelay(tripID: String, stopID: String) -> Endpoint {
         let queryItems = GetDelayBody(stopID: stopID, tripID: tripID).toQueryItems()
+        print(queryItems)
         return Endpoint(path: Constants.Endpoints.delay, queryItems: queryItems)
     }
-
+    
+    static func getAllDelays(trips: [Trip]) -> Endpoint {
+        let body = TripBody(data: trips)
+        print(body)
+        return Endpoint(path: Constants.Endpoints.delays, body: body)
+    }
+    
     static func getDelayUrl(tripId: String, stopId: String) -> String {
         let path = "delay"
 

--- a/TCAT/Network/Models.swift
+++ b/TCAT/Network/Models.swift
@@ -71,6 +71,21 @@ internal struct GetDelayBody: Codable {
     }
 }
 
+internal struct Trip: Codable {
+    let stopID: String
+    let tripID: String
+}
+
+internal struct TripBody: Codable {
+    var data: [Trip]
+}
+
+internal struct Delay: Codable {
+    let stopID: String
+    let tripID: String
+    let delay: Int?
+}
+
 // Response
 struct Response<T: Codable>: Codable {
     var success: Bool

--- a/TCAT/Supporting Files/Constants.swift
+++ b/TCAT/Supporting Files/Constants.swift
@@ -166,6 +166,7 @@ struct Constants {
         static let appleSearch = "/appleSearch"
         static let busLocations = "/tracking"
         static let delay = "/delay"
+        static let delays = "/delays"
         static let getRoutes = "/route"
         static let multiRoute = "/multiroute"
         static let placeIDCoordinates = "/placeIDCoordinates"

--- a/TCAT/Utilities/JSONFileManager.swift
+++ b/TCAT/Utilities/JSONFileManager.swift
@@ -12,7 +12,7 @@ import Zip
 
 enum JSONType {
     case routeJSON
-    case delayJSON(rowNum: Int)
+    case delayJSON(routeId: String)
 
     func rawValue() -> String {
         switch self {
@@ -182,7 +182,7 @@ class JSONFileManager {
         logLine(timestamp: timestamp, line: "Search parameters: startPlace: \(startPlace). endPlace: \(endPlace). searchTime: \(Time.dateString(from: searchTime)). searchTimeType: \(searchTimeType)")
     }
 
-    func logDelayParemeters(timestamp: Date, stopId: String, tripId: String) {
+    func logDelayParameters(timestamp: Date, stopId: String, tripId: String) {
         logLine(timestamp: timestamp, line: "Delay parameters: stopId: \(stopId). tripId: \(tripId).")
     }
 
@@ -245,8 +245,8 @@ class JSONFileManager {
         switch type {
         case .routeJSON:
             return "\(dateString) \(jsonString)"
-        case .delayJSON(rowNum: let num):
-            return "\(dateString) \(jsonString) \(num)"
+        case .delayJSON(routeId: let routeId):
+            return "\(dateString) \(jsonString) \(routeId)"
         }
     }
 


### PR DESCRIPTION
**Addresses Issue #316 and Is an Extension of my Previous PR #317** 

_Background:_
- Issue was to move all live tracking logic out of the route cells into the route options view controller because having the logic in the cell was causing a lot of instabilities and crashes within our app
- This PR extends #317, where I initially moved the live tracking logic into the routes option view controller using our previous /delay endpoint to retrieve delays for each route
- For this PR, I updated my code to now use Alanna's new /delays endpoint so that I get delays for all routes at once

_New Things:_
- I added a new /delays route to our networking files and also created a trip dictionary so that we can map from route to trip and back. 
- I updated the way we did JSON logging so that we use routeId as opposed to rowNum because rowNum is pretty arbitrary to how our table renders the routes.

_Some Questions:_
- Right now, I'm rendering my trips array inside of my "updateAllRoutesLiveTracking" function, which fires every 5 seconds. Should I move that into our searchForRoutes() function instead so that the trips array is instantiated the same time our routes are?
- I am currently updating table every 20 seconds and fetching delays every 5 seconds. Let me know if I should change those numbers!