### PR TITLE
Standardize logging with print statement

### DIFF
--- a/TCAT/Controllers/AllStopsTableViewController.swift
+++ b/TCAT/Controllers/AllStopsTableViewController.swift
@@ -41,6 +41,7 @@ class AllStopsTableViewController: UIViewController {
         setupConstraints()
 
         refreshAllStops()
+        Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: "some error")
     }
 
     private func setupTableView() {
@@ -151,14 +152,14 @@ class AllStopsTableViewController: UIViewController {
                             let encodedObject = try JSONEncoder().encode(response.data)
                             userDefaults.set(encodedObject, forKey: Constants.UserDefaults.allBusStops)
                         } catch let error {
-                            print(error)
+                            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                         }
                         let collegetownStop = Place(name: "Collegetown", latitude: 42.442558, longitude: -76.485336)
                         response.data.append(collegetownStop)
                         self.allStops = response.data
                     }
                 case .error(let error):
-                    print("AllStopsTableViewController.retryNetwork error:", error)
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                 }
                 self.loadingIndicator?.removeFromSuperview()
                 self.loadingIndicator = nil

--- a/TCAT/Controllers/AllStopsTableViewController.swift
+++ b/TCAT/Controllers/AllStopsTableViewController.swift
@@ -151,14 +151,14 @@ class AllStopsTableViewController: UIViewController {
                             let encodedObject = try JSONEncoder().encode(response.data)
                             userDefaults.set(encodedObject, forKey: Constants.UserDefaults.allBusStops)
                         } catch let error {
-                            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                            self.printClass(context: "\(#function) error", message: error.localizedDescription)
                         }
                         let collegetownStop = Place(name: "Collegetown", latitude: 42.442558, longitude: -76.485336)
                         response.data.append(collegetownStop)
                         self.allStops = response.data
                     }
                 case .error(let error):
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                    self.printClass(context: "\(#function) error", message: error.localizedDescription)
                 }
                 self.loadingIndicator?.removeFromSuperview()
                 self.loadingIndicator = nil

--- a/TCAT/Controllers/AllStopsTableViewController.swift
+++ b/TCAT/Controllers/AllStopsTableViewController.swift
@@ -41,7 +41,6 @@ class AllStopsTableViewController: UIViewController {
         setupConstraints()
 
         refreshAllStops()
-        Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: "some error")
     }
 
     private func setupTableView() {

--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -159,7 +159,7 @@ extension FavoritesTableViewController: UISearchBarDelegate {
                 guard let `self` = self else { return }
                 DispatchQueue.main.async {
                     if let error = error {
-                        Analytics.shared.logWithPrintStatement(currentClass: self, context: "SearchManager lookup error", message: error.localizedDescription)
+                        self.printClass(context: "SearchManager lookup error", message: error.localizedDescription)
                         self.resultsSection = Section.recentSearches(items: [])
                         return
                     }

--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -159,7 +159,7 @@ extension FavoritesTableViewController: UISearchBarDelegate {
                 guard let `self` = self else { return }
                 DispatchQueue.main.async {
                     if let error = error {
-                        print("[FavoritesTableViewController] SearchManager lookup Error: \(error.localizedDescription)")
+                        Analytics.shared.logWithPrintStatement(currentClass: self, context: "SearchManager lookup error", message: error.localizedDescription)
                         self.resultsSection = Section.recentSearches(items: [])
                         return
                     }

--- a/TCAT/Controllers/HomeMapViewController.swift
+++ b/TCAT/Controllers/HomeMapViewController.swift
@@ -79,7 +79,7 @@ class HomeMapViewController: UIViewController {
         do {
             try reachability?.startNotifier()
         } catch {
-            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "Could not start reachability notifier")
+            printClass(context: "\(#function)", message: "Could not start reachability notifier")
         }
     }
 

--- a/TCAT/Controllers/HomeMapViewController.swift
+++ b/TCAT/Controllers/HomeMapViewController.swift
@@ -79,7 +79,7 @@ class HomeMapViewController: UIViewController {
         do {
             try reachability?.startNotifier()
         } catch {
-            print("HomeVC viewDidLayoutSubviews: Could not start reachability notifier")
+            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "Could not start reachability notifier")
         }
     }
 

--- a/TCAT/Controllers/HomeOptionsCardViewController.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController.swift
@@ -282,7 +282,7 @@ class HomeOptionsCardViewController: UIViewController {
             SearchManager.shared.performLookup(for: searchText) { [weak self] (searchResults, error) in
                 guard let `self` = self else { return }
                 if let error = error {
-                    print("[HomeOptionsCardViewController] SearchManager lookup Error: \(error.localizedDescription)")
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "SearchManager lookup error", message: error.localizedDescription)
                     return
                 }
                 DispatchQueue.main.async {

--- a/TCAT/Controllers/HomeOptionsCardViewController.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController.swift
@@ -282,7 +282,7 @@ class HomeOptionsCardViewController: UIViewController {
             SearchManager.shared.performLookup(for: searchText) { [weak self] (searchResults, error) in
                 guard let `self` = self else { return }
                 if let error = error {
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "SearchManager lookup error", message: error.localizedDescription)
+                    self.printClass(context: "SearchManager lookup error", message: error.localizedDescription)
                     return
                 }
                 DispatchQueue.main.async {

--- a/TCAT/Controllers/InformationViewController.swift
+++ b/TCAT/Controllers/InformationViewController.swift
@@ -248,7 +248,7 @@ extension InformationViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Swift.Error?) {
         controller.dismiss(animated: true)
         if let error = error {
-            print("Mail Error:", error)
+            Analytics.shared.logWithPrintStatement(currentClass: self, context: "Mail error", message: error.localizedDescription)
         }
     }
 }

--- a/TCAT/Controllers/InformationViewController.swift
+++ b/TCAT/Controllers/InformationViewController.swift
@@ -248,7 +248,7 @@ extension InformationViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Swift.Error?) {
         controller.dismiss(animated: true)
         if let error = error {
-            Analytics.shared.logWithPrintStatement(currentClass: self, context: "Mail error", message: error.localizedDescription)
+            printClass(context: "Mail error", message: error.localizedDescription)
         }
     }
 }

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -180,7 +180,7 @@ class RouteDetailContentViewController: UIViewController {
             }
         }
         if !directionsAreValid {
-            print("getBusLocations - Directions are not valid")
+            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "Directions are not valid")
             return
         }
 
@@ -195,7 +195,7 @@ class RouteDetailContentViewController: UIViewController {
                     }
                     self.parseBusLocationsData(data: response.data)
                 case .error(let error):
-                    print("RouteDetailVC getBusLocations Error:", error.localizedDescription)
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                     if let banner = self.banner, !banner.isDisplaying {
                         self.showBanner(Constants.Banner.cannotConnectLive, status: .danger)
                     }

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -180,7 +180,7 @@ class RouteDetailContentViewController: UIViewController {
             }
         }
         if !directionsAreValid {
-            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "Directions are not valid")
+            printClass(context: "\(#function)", message: "Directions are not valid")
             return
         }
 
@@ -195,7 +195,7 @@ class RouteDetailContentViewController: UIViewController {
                     }
                     self.parseBusLocationsData(data: response.data)
                 case .error(let error):
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                    self.printClass(context: "\(#function) error", message: error.localizedDescription)
                     if let banner = self.banner, !banner.isDisplaying {
                         self.showBanner(Constants.Banner.cannotConnectLive, status: .danger)
                     }

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -190,10 +190,10 @@ class RouteDetailDrawerViewController: UIViewController {
                             self.tableView.reloadData()
                             self.summaryView.updateTimes(for: self.route)
                         } else {
-                            print("getDelays success: false")
+                            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) success", message: "false")
                         }
                     case .error(let error):
-                        print("getDelays error: \(error.localizedDescription)")
+                        Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                     }
                 }
             })

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -190,10 +190,10 @@ class RouteDetailDrawerViewController: UIViewController {
                             self.tableView.reloadData()
                             self.summaryView.updateTimes(for: self.route)
                         } else {
-                            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) success", message: "false")
+                            self.printClass(context: "\(#function) success", message: "false")
                         }
                     case .error(let error):
-                        Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                        self.printClass(context: "\(#function) error", message: error.localizedDescription)
                     }
                 }
             })

--- a/TCAT/Controllers/RouteDetailContentViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailContentViewController+Extensions.swift
@@ -87,7 +87,7 @@ extension RouteDetailContentViewController: CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
-        print("RouteDetailVC CLLocationManager didFailWithError: \(error)")
+        Analytics.shared.logWithPrintStatement(currentClass: self, context: "CLLocationManager didFailWithError", message: error.localizedDescription)
         didUpdateLocation()
     }
 }

--- a/TCAT/Controllers/RouteDetailContentViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailContentViewController+Extensions.swift
@@ -87,7 +87,7 @@ extension RouteDetailContentViewController: CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
-        Analytics.shared.logWithPrintStatement(currentClass: self, context: "CLLocationManager didFailWithError", message: error.localizedDescription)
+        printClass(context: "CLLocationManager didFailWithError", message: error.localizedDescription)
         didUpdateLocation()
     }
 }

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -118,7 +118,7 @@ extension RouteOptionsViewController: DatePickerViewDelegate {
 extension RouteOptionsViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
-        print("\(#file) \(#function): \(error.localizedDescription)")
+        Analytics.shared.logWithPrintStatement(currentClass: self, context: ("CLLocationManager didFailWithError"), message: error.localizedDescription)
 
         if error._code == CLError.denied.rawValue {
             locationManager.stopUpdatingLocation()

--- a/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteOptionsViewController+Extensions.swift
@@ -118,7 +118,7 @@ extension RouteOptionsViewController: DatePickerViewDelegate {
 extension RouteOptionsViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
-        Analytics.shared.logWithPrintStatement(currentClass: self, context: ("CLLocationManager didFailWithError"), message: error.localizedDescription)
+        printClass(context: ("CLLocationManager didFailWithError"), message: error.localizedDescription)
 
         if error._code == CLError.denied.rawValue {
             locationManager.stopUpdatingLocation()

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -344,7 +344,6 @@ class RouteOptionsViewController: UIViewController {
                         return
                 }
                 getDelay(tripId: tripId, stopId: stopId).observe(with: { result in
-                    let fileName = "RouteTableViewCell"
                     DispatchQueue.main.async {
                         switch result {
                         case .value (let delayResponse):
@@ -357,8 +356,7 @@ class RouteOptionsViewController: UIViewController {
                                 JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: tripId, stopId: stopId))
                                 if let data = try? JSONEncoder().encode(delayResponse) {
                                     do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: index)) } catch let error {
-                                        let line = "\(fileName) \(#function): \(error.localizedDescription)"
-                                        print(line)
+                                        Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) delayResponse error", message: error.localizedDescription)
                                     }
                                 }
                             }
@@ -375,7 +373,7 @@ class RouteOptionsViewController: UIViewController {
                             route.getFirstDepartRawDirection()?.delay = delay
 
                         case .error (let error):
-                            print(error)
+                            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                         }
                     }
                 })
@@ -492,13 +490,13 @@ class RouteOptionsViewController: UIViewController {
 
     func routeSelected(routeId: String) {
         networking(Endpoint.routeSelected(routeId: routeId)).observe { [weak self] result in
-            guard self != nil else { return }
+            guard let `self` = self else { return }
             DispatchQueue.main.async {
                 switch result {
                 case .value:
-                    print("[RouteOptionsViewController] Route Selected - Success")
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "success")
                 case .error(let error):
-                    print("[RouteOptionsViewController] Route Selected - Error:", error)
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                 }
             }
         }
@@ -512,9 +510,7 @@ class RouteOptionsViewController: UIViewController {
             // Save to JSONFileManager
             if let data = try? JSONEncoder().encode(response) {
                 do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .routeJSON) } catch let error {
-                    let fileName = "RouteOptionsViewController"
-                    let line = "\(fileName) \(#function): \(error.localizedDescription)"
-                    print(line)
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                 }
             }
             // Parse sections of routes
@@ -618,7 +614,7 @@ class RouteOptionsViewController: UIViewController {
         do {
             try reachability?.startNotifier()
         } catch {
-            print("\(#file) \(#function): Could not start reachability notifier")
+            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "Could not start reachability notifier")
         }
     }
 

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -356,7 +356,7 @@ class RouteOptionsViewController: UIViewController {
                                 JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: tripId, stopId: stopId))
                                 if let data = try? JSONEncoder().encode(delayResponse) {
                                     do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(rowNum: index)) } catch let error {
-                                        Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) delayResponse error", message: error.localizedDescription)
+                                        self.printClass(context: "\(#function) delayResponse error", message: error.localizedDescription)
                                     }
                                 }
                             }
@@ -373,7 +373,7 @@ class RouteOptionsViewController: UIViewController {
                             route.getFirstDepartRawDirection()?.delay = delay
 
                         case .error (let error):
-                            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                            self.printClass(context: "\(#function) error", message: error.localizedDescription)
                         }
                     }
                 })
@@ -494,9 +494,9 @@ class RouteOptionsViewController: UIViewController {
             DispatchQueue.main.async {
                 switch result {
                 case .value:
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "success")
+                    self.printClass(context: "\(#function)", message: "success")
                 case .error(let error):
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                    self.printClass(context: "\(#function) error", message: error.localizedDescription)
                 }
             }
         }
@@ -510,7 +510,7 @@ class RouteOptionsViewController: UIViewController {
             // Save to JSONFileManager
             if let data = try? JSONEncoder().encode(response) {
                 do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .routeJSON) } catch let error {
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                    printClass(context: "\(#function) error", message: error.localizedDescription)
                 }
             }
             // Parse sections of routes
@@ -614,7 +614,7 @@ class RouteOptionsViewController: UIViewController {
         do {
             try reachability?.startNotifier()
         } catch {
-            Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function)", message: "Could not start reachability notifier")
+            printClass(context: "\(#function)", message: "Could not start reachability notifier")
         }
     }
 

--- a/TCAT/Controllers/SearchResultsViewController.swift
+++ b/TCAT/Controllers/SearchResultsViewController.swift
@@ -159,7 +159,7 @@ class SearchResultsViewController: UIViewController {
             SearchManager.shared.performLookup(for: searchText) { [weak self] (searchResults, error) in
                 guard let `self` = self else { return }
                 if let error = error {
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "SearchManager lookup error", message: error.localizedDescription)
+                    self.printClass(context: "SearchManager lookup error", message: error.localizedDescription)
                     return
                 }
                 DispatchQueue.main.async {
@@ -329,7 +329,7 @@ extension SearchResultsViewController: CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
-        Analytics.shared.logWithPrintStatement(currentClass: self, context: "CLLocationManager didFailWithError", message: error.localizedDescription)
+        printClass(context: "CLLocationManager didFailWithError", message: error.localizedDescription)
         // This means they dont have location services enabled. We catch this.
         if error._code == CLError.denied.rawValue {
             currentLocation = nil

--- a/TCAT/Controllers/SearchResultsViewController.swift
+++ b/TCAT/Controllers/SearchResultsViewController.swift
@@ -159,7 +159,7 @@ class SearchResultsViewController: UIViewController {
             SearchManager.shared.performLookup(for: searchText) { [weak self] (searchResults, error) in
                 guard let `self` = self else { return }
                 if let error = error {
-                    print("[SearchResultsViewController] SearchManager lookup Error: \(error.localizedDescription)")
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "SearchManager lookup error", message: error.localizedDescription)
                     return
                 }
                 DispatchQueue.main.async {
@@ -329,7 +329,7 @@ extension SearchResultsViewController: CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
-        print("SearchResultsTableVC CLLocationManager didFailWithError: \(error)")
+        Analytics.shared.logWithPrintStatement(currentClass: self, context: "CLLocationManager didFailWithError", message: error.localizedDescription)
         // This means they dont have location services enabled. We catch this.
         if error._code == CLError.denied.rawValue {
             currentLocation = nil

--- a/TCAT/Controllers/ServiceAlertsViewController.swift
+++ b/TCAT/Controllers/ServiceAlertsViewController.swift
@@ -114,7 +114,7 @@ class ServiceAlertsViewController: UIViewController {
                     self.removeLoadingIndicator()
                     self.networkError = true
                     self.alerts = [:]
-                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
+                    self.printClass(context: "\(#function) error", message: error.localizedDescription)
                 }
             }
         })

--- a/TCAT/Controllers/ServiceAlertsViewController.swift
+++ b/TCAT/Controllers/ServiceAlertsViewController.swift
@@ -110,10 +110,11 @@ class ServiceAlertsViewController: UIViewController {
                         self.networkError = false
                         self.alerts = self.sortedAlerts(alertsList: response.data)
                     }
-                case .error:
+                case .error (let error):
                     self.removeLoadingIndicator()
                     self.networkError = true
                     self.alerts = [:]
+                    Analytics.shared.logWithPrintStatement(currentClass: self, context: "\(#function) error", message: error.localizedDescription)
                 }
             }
         })

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -20,6 +20,11 @@ class Analytics {
             Answers.logCustomEvent(withName: fabricEvent.name, customAttributes: fabricEvent.attributes)
         #endif
     }
+    
+    func logWithPrintStatement(currentClass: Any, context: String, message: String) {
+        let className = String(describing: currentClass)
+        print("[\(className)] \(context): \(message)")
+    }
 }
 
 extension Payload {

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -20,11 +20,6 @@ class Analytics {
             Answers.logCustomEvent(withName: fabricEvent.name, customAttributes: fabricEvent.attributes)
         #endif
     }
-    
-    func logWithPrintStatement(currentClass: Any, context: String, message: String) {
-        let className = String(describing: currentClass)
-        print("[\(className)] \(context): \(message)")
-    }
 }
 
 extension Payload {

--- a/TCAT/Utilities/Extensions+Shared.swift
+++ b/TCAT/Utilities/Extensions+Shared.swift
@@ -192,3 +192,10 @@ extension Date {
         return Time.truncateSeconds(from: date)
     }
 }
+
+extension NSObject {
+    func printClass(context: String, message: String) {
+        let className = String(describing: self)
+        print("[\(className)] \(context): \(message)") 
+    }
+}


### PR DESCRIPTION
For #305 

Standardize logging with print statement using a helper method. We don't need to always put in class names. 

Prints something like this: 
<img width="635" alt="Screen Shot 2019-10-11 at 8 02 09 PM" src="https://user-images.githubusercontent.com/48968041/66691539-2f3eaf00-ec65-11e9-9789-f9a1101e48e9.png">
