### PR TITLE
Daniel/did update location excess calls

### DIFF
--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -10,6 +10,11 @@ import UIKit
 import DZNEmptyDataSet
 import FutureNova
 
+protocol FavoritesSelectionDelegate: class {
+    /** Indicates to `HomeMapViewController` that it should reload its table. */
+    func didAddNewFavorite()
+}
+
 class FavoritesTableViewController: UIViewController {
 
     private var searchBar = UISearchBar()
@@ -174,9 +179,4 @@ extension FavoritesTableViewController: UISearchBarDelegate {
         }
     }
 
-}
-
-protocol FavoritesSelectionDelegate: class {
-    /** Indicates to `HomeMapViewController` that it should reload its table. */
-    func didAddNewFavorite()
 }

--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -22,7 +22,9 @@ class FavoritesTableViewController: UIViewController {
             tableView.reloadData()
         }
     }
-
+    
+    weak var selectionDelegate: FavoritesSelectionDelegate?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -118,6 +120,7 @@ extension FavoritesTableViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
         if let place = resultsSection.getItem(at: indexPath.row) {
             Global.shared.insertPlace(for: Constants.UserDefaults.favorites, place: place, bottom: true)
+            selectionDelegate?.didAddNewFavorite()
             dismissVC()
         }
     }
@@ -171,4 +174,9 @@ extension FavoritesTableViewController: UISearchBarDelegate {
         }
     }
 
+}
+
+protocol FavoritesSelectionDelegate: class {
+    /** Indicates to `HomeMapViewController` that it should reload its table. */
+    func didAddNewFavorite()
 }

--- a/TCAT/Controllers/FavoritesTableViewController.swift
+++ b/TCAT/Controllers/FavoritesTableViewController.swift
@@ -11,7 +11,7 @@ import DZNEmptyDataSet
 import FutureNova
 
 protocol FavoritesSelectionDelegate: class {
-    /** Indicates to `HomeMapViewController` that it should reload its table. */
+    /// Indicates to `HomeMapViewController` that it should reload its table. 
     func didAddNewFavorite()
 }
 

--- a/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
@@ -282,7 +282,9 @@ extension HomeOptionsCardViewController: UITableViewDelegate {
 }
 
 extension HomeOptionsCardViewController: FavoritesSelectionDelegate {
+    
     func didAddNewFavorite() {
         updatePlaces()
     }
+    
 }

--- a/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
@@ -284,6 +284,5 @@ extension HomeOptionsCardViewController: UITableViewDelegate {
 extension HomeOptionsCardViewController: FavoritesSelectionDelegate {
     func didAddNewFavorite() {
         updatePlaces()
-//        tableView.reloadData()
     }
 }

--- a/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
@@ -280,3 +280,10 @@ extension HomeOptionsCardViewController: UITableViewDelegate {
         }
     }
 }
+
+extension HomeOptionsCardViewController: FavoritesSelectionDelegate {
+    func didAddNewFavorite() {
+        updatePlaces()
+//        tableView.reloadData()
+    }
+}

--- a/TCAT/Controllers/HomeOptionsCardViewController.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController.swift
@@ -263,6 +263,7 @@ class HomeOptionsCardViewController: UIViewController {
 
     @objc func presentFavoritesTVC(sender: UIButton? = nil) {
         let favoritesTVC = FavoritesTableViewController()
+        favoritesTVC.selectionDelegate = self
         let navController = CustomNavigationController(rootViewController: favoritesTVC)
         present(navController, animated: true, completion: nil)
     }

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -27,7 +27,7 @@ class RouteDetailContentViewController: UIViewController {
     var buses = [GMSMarker]()
     var currentLocation: CLLocationCoordinate2D?
     var directions: [Direction] = []
-    private var initalUpdate: Bool = true
+    private(set) var isInitalUpdate: Bool = true
     /// Number of seconds to wait before auto-refreshing live tracking network call call, timed with live indicator
     var liveTrackingNetworkRefreshRate: Double = LiveIndicator.INTERVAL * 1.0
     var liveTrackingNetworkTimer: Timer?
@@ -459,8 +459,8 @@ class RouteDetailContentViewController: UIViewController {
     /// Completion after locationManager functions return
     func didUpdateLocation() {
         // TODO #267: Find better way to cut down on didUpdateLocation calls
-        if initalUpdate {
-            initalUpdate = false
+        if isInitalUpdate {
+            isInitalUpdate = false
             drawMapRoute()
             centerMapOnOverview(drawerPreviewing: true)
         }

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -458,7 +458,6 @@ class RouteDetailContentViewController: UIViewController {
 
     /// Completion after locationManager functions return
     func didUpdateLocation() {
-        // TODO #267: Find better way to cut down on didUpdateLocation calls
         if isInitalUpdate {
             isInitalUpdate = false
             drawMapRoute()

--- a/TCAT/Controllers/RouteDetailContentViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailContentViewController+Extensions.swift
@@ -83,12 +83,18 @@ extension RouteDetailContentViewController: CLLocationManagerDelegate {
             bounds = bounds.includingCoordinate(newCoord)
             currentLocation = newCoord
         }
-        didUpdateLocation()
+        
+        if isInitalUpdate {
+            didUpdateLocation()
+        }
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
         print("RouteDetailVC CLLocationManager didFailWithError: \(error)")
-        didUpdateLocation()
+        
+        if isInitalUpdate {
+            didUpdateLocation()
+        }
     }
 }
 


### PR DESCRIPTION
This is a solution to issue #267. I made `isInitialUpdate` private(set) instead of private so it is accessible from extensions. The two location manager delegate methods that call `didUpdateLocation` now check if `isInitialUpdate` first. The if statements should reduce overhead compared to function calls, but honestly I'm not sure if it is a meaningful difference from a performance perspective.

Also, I'm not sure why the commits on my last branch are in this pull request. I thought they were already squashed and I'm on a new branch.