### PR TITLE
Standardize error handling

### DIFF
--- a/TCAT/Controllers/AllStopsTableViewController.swift
+++ b/TCAT/Controllers/AllStopsTableViewController.swift
@@ -152,7 +152,7 @@ class AllStopsTableViewController: UIViewController {
                             userDefaults.set(encodedObject, forKey: Constants.UserDefaults.allBusStops)
                         } catch let error {
                             self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                            let payload = GetErrorPayload(
+                            let payload = NetworkErrorPayload(
                                 location: "\(self) Get All Stops",
                                 type: "\((error as NSError).domain)",
                                 description: error.localizedDescription)
@@ -164,7 +164,7 @@ class AllStopsTableViewController: UIViewController {
                     }
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = GetErrorPayload(
+                    let payload = NetworkErrorPayload(
                         location: "\(self) Get All Stops",
                         type: "\((error as NSError).domain)",
                         description: error.localizedDescription)

--- a/TCAT/Controllers/AllStopsTableViewController.swift
+++ b/TCAT/Controllers/AllStopsTableViewController.swift
@@ -41,7 +41,6 @@ class AllStopsTableViewController: UIViewController {
         setupConstraints()
 
         refreshAllStops()
-        print("\(self)")
     }
 
     private func setupTableView() {
@@ -153,6 +152,8 @@ class AllStopsTableViewController: UIViewController {
                             userDefaults.set(encodedObject, forKey: Constants.UserDefaults.allBusStops)
                         } catch let error {
                             self.printClass(context: "\(#function) error", message: error.localizedDescription)
+                            let payload = GetErrorPayload(location: "\(self) Get All Stops", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                            Analytics.shared.log(payload)
                         }
                         let collegetownStop = Place(name: "Collegetown", latitude: 42.442558, longitude: -76.485336)
                         response.data.append(collegetownStop)
@@ -160,7 +161,7 @@ class AllStopsTableViewController: UIViewController {
                     }
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    let payload = GetErrorPayload(location: "\(self) Get All Stops", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
                     Analytics.shared.log(payload)
                 }
                 self.loadingIndicator?.removeFromSuperview()

--- a/TCAT/Controllers/AllStopsTableViewController.swift
+++ b/TCAT/Controllers/AllStopsTableViewController.swift
@@ -41,6 +41,7 @@ class AllStopsTableViewController: UIViewController {
         setupConstraints()
 
         refreshAllStops()
+        print("\(self)")
     }
 
     private func setupTableView() {
@@ -159,6 +160,8 @@ class AllStopsTableViewController: UIViewController {
                     }
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
+                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    Analytics.shared.log(payload)
                 }
                 self.loadingIndicator?.removeFromSuperview()
                 self.loadingIndicator = nil

--- a/TCAT/Controllers/AllStopsTableViewController.swift
+++ b/TCAT/Controllers/AllStopsTableViewController.swift
@@ -152,7 +152,10 @@ class AllStopsTableViewController: UIViewController {
                             userDefaults.set(encodedObject, forKey: Constants.UserDefaults.allBusStops)
                         } catch let error {
                             self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                            let payload = GetErrorPayload(location: "\(self) Get All Stops", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                            let payload = GetErrorPayload(
+                                location: "\(self) Get All Stops",
+                                type: "\((error as NSError).domain)",
+                                description: error.localizedDescription)
                             Analytics.shared.log(payload)
                         }
                         let collegetownStop = Place(name: "Collegetown", latitude: 42.442558, longitude: -76.485336)
@@ -161,7 +164,10 @@ class AllStopsTableViewController: UIViewController {
                     }
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = GetErrorPayload(location: "\(self) Get All Stops", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                    let payload = GetErrorPayload(
+                        location: "\(self) Get All Stops",
+                        type: "\((error as NSError).domain)",
+                        description: error.localizedDescription)
                     Analytics.shared.log(payload)
                 }
                 self.loadingIndicator?.removeFromSuperview()

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -181,6 +181,8 @@ class RouteDetailContentViewController: UIViewController {
         }
         if !directionsAreValid {
             printClass(context: "\(#function)", message: "Directions are not valid")
+            let payload = GetErrorPayload(location: "\(self) Get Bus Locations", type: "Invalid Directions", description: "Directions are not valid", url: nil)
+            Analytics.shared.log(payload)  
             return
         }
 
@@ -199,7 +201,7 @@ class RouteDetailContentViewController: UIViewController {
                     if let banner = self.banner, !banner.isDisplaying {
                         self.showBanner(Constants.Banner.cannotConnectLive, status: .danger)
                     }
-                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    let payload = GetErrorPayload(location: "\(self) Get Bus Locations", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
                     Analytics.shared.log(payload)
                 }
             }

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -181,7 +181,10 @@ class RouteDetailContentViewController: UIViewController {
         }
         if !directionsAreValid {
             printClass(context: "\(#function)", message: "Directions are not valid")
-            let payload = GetErrorPayload(location: "\(self) Get Bus Locations", type: "Invalid Directions", description: "Directions are not valid", url: nil)
+            let payload = GetErrorPayload(
+                location: "\(self) Get Bus Locations",
+                type: "Invalid Directions",
+                description: "Directions are not valid")
             Analytics.shared.log(payload)  
             return
         }
@@ -201,7 +204,10 @@ class RouteDetailContentViewController: UIViewController {
                     if let banner = self.banner, !banner.isDisplaying {
                         self.showBanner(Constants.Banner.cannotConnectLive, status: .danger)
                     }
-                    let payload = GetErrorPayload(location: "\(self) Get Bus Locations", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                    let payload = GetErrorPayload(
+                        location: "\(self) Get Bus Locations",
+                        type: "\((error as NSError).domain)",
+                        description: error.localizedDescription)
                     Analytics.shared.log(payload)
                 }
             }

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -199,6 +199,8 @@ class RouteDetailContentViewController: UIViewController {
                     if let banner = self.banner, !banner.isDisplaying {
                         self.showBanner(Constants.Banner.cannotConnectLive, status: .danger)
                     }
+                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    Analytics.shared.log(payload)
                 }
             }
         }

--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -181,7 +181,7 @@ class RouteDetailContentViewController: UIViewController {
         }
         if !directionsAreValid {
             printClass(context: "\(#function)", message: "Directions are not valid")
-            let payload = GetErrorPayload(
+            let payload = NetworkErrorPayload(
                 location: "\(self) Get Bus Locations",
                 type: "Invalid Directions",
                 description: "Directions are not valid")
@@ -204,7 +204,7 @@ class RouteDetailContentViewController: UIViewController {
                     if let banner = self.banner, !banner.isDisplaying {
                         self.showBanner(Constants.Banner.cannotConnectLive, status: .danger)
                     }
-                    let payload = GetErrorPayload(
+                    let payload = NetworkErrorPayload(
                         location: "\(self) Get Bus Locations",
                         type: "\((error as NSError).domain)",
                         description: error.localizedDescription)

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -191,12 +191,18 @@ class RouteDetailDrawerViewController: UIViewController {
                             self.summaryView.updateTimes(for: self.route)
                         } else {
                             self.printClass(context: "\(#function) success", message: "false")
-                            let payload = GetErrorPayload(location: "\(self) Get Delay", type: "Response Failure", description: "Response Failure", url: nil)
+                            let payload = GetErrorPayload(
+                                location: "\(self) Get Delay",
+                                type: "Response Failure",
+                                description: "Response Failure")
                             Analytics.shared.log(payload)
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                        let payload = GetErrorPayload(location: "\(self) Get Delay", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                        let payload = GetErrorPayload(
+                            location: "\(self) Get Delay",
+                            type: "\((error as NSError).domain)",
+                            description: error.localizedDescription)
                         Analytics.shared.log(payload)
                     }
                 }

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -191,10 +191,12 @@ class RouteDetailDrawerViewController: UIViewController {
                             self.summaryView.updateTimes(for: self.route)
                         } else {
                             self.printClass(context: "\(#function) success", message: "false")
+                            let payload = GetErrorPayload(location: "\(self) Get Delay", type: "Response Failure", description: "Response Failure", url: nil)
+                            Analytics.shared.log(payload)
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                        let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                        let payload = GetErrorPayload(location: "\(self) Get Delay", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
                         Analytics.shared.log(payload)
                     }
                 }

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -191,7 +191,7 @@ class RouteDetailDrawerViewController: UIViewController {
                             self.summaryView.updateTimes(for: self.route)
                         } else {
                             self.printClass(context: "\(#function) success", message: "false")
-                            let payload = GetErrorPayload(
+                            let payload = NetworkErrorPayload(
                                 location: "\(self) Get Delay",
                                 type: "Response Failure",
                                 description: "Response Failure")
@@ -199,7 +199,7 @@ class RouteDetailDrawerViewController: UIViewController {
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                        let payload = GetErrorPayload(
+                        let payload = NetworkErrorPayload(
                             location: "\(self) Get Delay",
                             type: "\((error as NSError).domain)",
                             description: error.localizedDescription)

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -194,6 +194,8 @@ class RouteDetailDrawerViewController: UIViewController {
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
+                        let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                        Analytics.shared.log(payload)
                     }
                 }
             })

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -357,7 +357,10 @@ class RouteOptionsViewController: UIViewController {
                                 if let data = try? JSONEncoder().encode(delayResponse) {
                                     do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(routeId: routeId)) } catch let error {
                                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                                        let payload = GetErrorPayload(location: "\(self) Get All Delays", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                                        let payload = GetErrorPayload(
+                                            location: "\(self) Get All Delays",
+                                            type: "\((error as NSError).domain)",
+                                            description: error.localizedDescription)
                                         Analytics.shared.log(payload)
                                     }
                                 }
@@ -376,7 +379,10 @@ class RouteOptionsViewController: UIViewController {
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                        let payload = GetErrorPayload(location: "\(self) Get All Delays", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                        let payload = GetErrorPayload(
+                            location: "\(self) Get All Delays",
+                            type: "\((error as NSError).domain)",
+                            description: error.localizedDescription)
                         Analytics.shared.log(payload)
                     }
                 }
@@ -432,8 +438,10 @@ class RouteOptionsViewController: UIViewController {
                 // Place(s) don't have coordinates assigned
                 self.requestDidFinish(perform: [
                     .showError(bannerInfo: BannerInfo(title: Constants.Banner.routeCalculationError, style: .danger),
-                               payload: GetErrorPayload(location: "\(self) Get Routes", type: "Nil Place Coordinates",
-                                                              description: "Place(s) don't have coordinates. (areValidCoordinates)", url: nil)
+                               payload: GetErrorPayload(
+                                location: "\(self) Get Routes",
+                                type: "Nil Place Coordinates",
+                                description: "Place(s) don't have coordinates. (areValidCoordinates)")
                     )
                     ])
                 return
@@ -448,7 +456,10 @@ class RouteOptionsViewController: UIViewController {
                 self.requestDidFinish(perform: [
                     .showAlert(title: title, message: message, actionTitle: actionTitle),
                     .showError(bannerInfo: BannerInfo(title: title, style: .warning),
-                               payload: GetErrorPayload(location: "\(self) Get Routes", type: title, description: message, url: nil))
+                               payload: GetErrorPayload(
+                                location: "\(self) Get Routes",
+                                type: title,
+                                description: message))
                     ])
                 return
             }
@@ -500,7 +511,10 @@ class RouteOptionsViewController: UIViewController {
                     self.printClass(context: "\(#function)", message: "success")
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = GetErrorPayload(location: "\(self) Get Route Selected", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                    let payload = GetErrorPayload(
+                        location: "\(self) Get Route Selected",
+                        type: "\((error as NSError).domain)",
+                        description: error.localizedDescription)
                     Analytics.shared.log(payload)
                 }
             }
@@ -566,7 +580,10 @@ class RouteOptionsViewController: UIViewController {
         routes = []
         requestDidFinish(perform: [
             .showError(bannerInfo: BannerInfo(title: Constants.Banner.cantConnectServer, style: .danger),
-                       payload: GetErrorPayload(location: "\(self) Get Routes", type: title, description: description, url: requestURL))
+                       payload: GetErrorPayload(
+                        location: "\(self) Get Routes",
+                        type: title,
+                        description: description))
         ])
     }
 

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -28,7 +28,7 @@ struct BannerInfo {
 enum RequestAction {
     case hideBanner
     case showAlert(title: String, message: String, actionTitle: String)
-    case showError(bannerInfo: BannerInfo, payload: GetRoutesErrorPayload)
+    case showError(bannerInfo: BannerInfo, payload: GetErrorPayload)
 }
 
 class RouteOptionsViewController: UIViewController {
@@ -357,6 +357,8 @@ class RouteOptionsViewController: UIViewController {
                                 if let data = try? JSONEncoder().encode(delayResponse) {
                                     do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(routeId: routeId)) } catch let error {
                                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
+                                        let payload = GetErrorPayload(location: "\(self) Get All Delays", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                                        Analytics.shared.log(payload)
                                     }
                                 }
                             }
@@ -374,7 +376,7 @@ class RouteOptionsViewController: UIViewController {
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                        let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                        let payload = GetErrorPayload(location: "\(self) Get All Delays", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
                         Analytics.shared.log(payload)
                     }
                 }
@@ -430,8 +432,9 @@ class RouteOptionsViewController: UIViewController {
                 // Place(s) don't have coordinates assigned
                 self.requestDidFinish(perform: [
                     .showError(bannerInfo: BannerInfo(title: Constants.Banner.routeCalculationError, style: .danger),
-                               payload: GetRoutesErrorPayload(type: "Nil Place Coordinates",
-                                                              description: "Place(s) don't have coordinates. (areValidCoordinates)", url: nil))
+                               payload: GetErrorPayload(location: "\(self) Get Routes", type: "Nil Place Coordinates",
+                                                              description: "Place(s) don't have coordinates. (areValidCoordinates)", url: nil)
+                    )
                     ])
                 return
             }
@@ -445,7 +448,7 @@ class RouteOptionsViewController: UIViewController {
                 self.requestDidFinish(perform: [
                     .showAlert(title: title, message: message, actionTitle: actionTitle),
                     .showError(bannerInfo: BannerInfo(title: title, style: .warning),
-                               payload: GetRoutesErrorPayload(type: title, description: message, url: nil))
+                               payload: GetErrorPayload(location: "\(self) Get Routes", type: title, description: message, url: nil))
                     ])
                 return
             }
@@ -497,7 +500,7 @@ class RouteOptionsViewController: UIViewController {
                     self.printClass(context: "\(#function)", message: "success")
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    let payload = GetErrorPayload(location: "\(self) Get Route Selected", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
                     Analytics.shared.log(payload)
                 }
             }
@@ -563,7 +566,7 @@ class RouteOptionsViewController: UIViewController {
         routes = []
         requestDidFinish(perform: [
             .showError(bannerInfo: BannerInfo(title: Constants.Banner.cantConnectServer, style: .danger),
-                       payload: GetRoutesErrorPayload(type: title, description: description, url: requestURL))
+                       payload: GetErrorPayload(location: "\(self) Get Routes", type: title, description: description, url: requestURL))
         ])
     }
 

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -350,15 +350,13 @@ class RouteOptionsViewController: UIViewController {
                                 let delay = delayResponse.delay else {
                                     continue
                             }
-                            let fileName = "RouteTableViewCell"
                             let isNewDelayValue = route.getFirstDepartRawDirection()?.delay != delay
                             if isNewDelayValue {
                                 JSONFileManager.shared.logDelayParameters(timestamp: Date(), stopId: delayResponse.stopID, tripId: delayResponse.tripID)
                                 JSONFileManager.shared.logURL(timestamp: Date(), urlName: "Delay requestUrl", url: Endpoint.getDelayUrl(tripId: delayResponse.tripID, stopId: delayResponse.stopID))
                                 if let data = try? JSONEncoder().encode(delayResponse) {
                                     do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(routeId: routeId)) } catch let error {
-                                        let line = "\(fileName) \(#function): \(error.localizedDescription)"
-                                        print(line)
+                                        self.printClass(context: "\(#function) error", message: error.localizedDescription)
                                     }
                                 }
                             }
@@ -376,6 +374,8 @@ class RouteOptionsViewController: UIViewController {
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
+                        let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                        Analytics.shared.log(payload)
                     }
                 }
             })
@@ -497,6 +497,8 @@ class RouteOptionsViewController: UIViewController {
                     self.printClass(context: "\(#function)", message: "success")
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
+                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    Analytics.shared.log(payload)
                 }
             }
         }

--- a/TCAT/Controllers/RouteOptionsViewController.swift
+++ b/TCAT/Controllers/RouteOptionsViewController.swift
@@ -28,7 +28,7 @@ struct BannerInfo {
 enum RequestAction {
     case hideBanner
     case showAlert(title: String, message: String, actionTitle: String)
-    case showError(bannerInfo: BannerInfo, payload: GetErrorPayload)
+    case showError(bannerInfo: BannerInfo, payload: NetworkErrorPayload)
 }
 
 class RouteOptionsViewController: UIViewController {
@@ -357,7 +357,7 @@ class RouteOptionsViewController: UIViewController {
                                 if let data = try? JSONEncoder().encode(delayResponse) {
                                     do { try JSONFileManager.shared.saveJSON(JSON.init(data: data), type: .delayJSON(routeId: routeId)) } catch let error {
                                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                                        let payload = GetErrorPayload(
+                                        let payload = NetworkErrorPayload(
                                             location: "\(self) Get All Delays",
                                             type: "\((error as NSError).domain)",
                                             description: error.localizedDescription)
@@ -379,7 +379,7 @@ class RouteOptionsViewController: UIViewController {
                         }
                     case .error(let error):
                         self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                        let payload = GetErrorPayload(
+                        let payload = NetworkErrorPayload(
                             location: "\(self) Get All Delays",
                             type: "\((error as NSError).domain)",
                             description: error.localizedDescription)
@@ -438,7 +438,7 @@ class RouteOptionsViewController: UIViewController {
                 // Place(s) don't have coordinates assigned
                 self.requestDidFinish(perform: [
                     .showError(bannerInfo: BannerInfo(title: Constants.Banner.routeCalculationError, style: .danger),
-                               payload: GetErrorPayload(
+                               payload: NetworkErrorPayload(
                                 location: "\(self) Get Routes",
                                 type: "Nil Place Coordinates",
                                 description: "Place(s) don't have coordinates. (areValidCoordinates)")
@@ -456,7 +456,7 @@ class RouteOptionsViewController: UIViewController {
                 self.requestDidFinish(perform: [
                     .showAlert(title: title, message: message, actionTitle: actionTitle),
                     .showError(bannerInfo: BannerInfo(title: title, style: .warning),
-                               payload: GetErrorPayload(
+                               payload: NetworkErrorPayload(
                                 location: "\(self) Get Routes",
                                 type: title,
                                 description: message))
@@ -511,7 +511,7 @@ class RouteOptionsViewController: UIViewController {
                     self.printClass(context: "\(#function)", message: "success")
                 case .error(let error):
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = GetErrorPayload(
+                    let payload = NetworkErrorPayload(
                         location: "\(self) Get Route Selected",
                         type: "\((error as NSError).domain)",
                         description: error.localizedDescription)
@@ -580,7 +580,7 @@ class RouteOptionsViewController: UIViewController {
         routes = []
         requestDidFinish(perform: [
             .showError(bannerInfo: BannerInfo(title: Constants.Banner.cantConnectServer, style: .danger),
-                       payload: GetErrorPayload(
+                       payload: NetworkErrorPayload(
                         location: "\(self) Get Routes",
                         type: title,
                         description: description))

--- a/TCAT/Controllers/ServiceAlertsViewController.swift
+++ b/TCAT/Controllers/ServiceAlertsViewController.swift
@@ -115,7 +115,7 @@ class ServiceAlertsViewController: UIViewController {
                     self.networkError = true
                     self.alerts = [:]
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = GetErrorPayload(
+                    let payload = NetworkErrorPayload(
                         location: "\(self) Get Alerts",
                         type: "\((error as NSError).domain)",
                         description: error.localizedDescription)

--- a/TCAT/Controllers/ServiceAlertsViewController.swift
+++ b/TCAT/Controllers/ServiceAlertsViewController.swift
@@ -115,7 +115,10 @@ class ServiceAlertsViewController: UIViewController {
                     self.networkError = true
                     self.alerts = [:]
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = GetErrorPayload(location: "\(self) Get Alerts", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
+                    let payload = GetErrorPayload(
+                        location: "\(self) Get Alerts",
+                        type: "\((error as NSError).domain)",
+                        description: error.localizedDescription)
                     Analytics.shared.log(payload)
                 }
             }

--- a/TCAT/Controllers/ServiceAlertsViewController.swift
+++ b/TCAT/Controllers/ServiceAlertsViewController.swift
@@ -115,7 +115,7 @@ class ServiceAlertsViewController: UIViewController {
                     self.networkError = true
                     self.alerts = [:]
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
-                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    let payload = GetErrorPayload(location: "\(self) Get Alerts", type: "\((error as NSError).domain)", description: error.localizedDescription, url: nil)
                     Analytics.shared.log(payload)
                 }
             }

--- a/TCAT/Controllers/ServiceAlertsViewController.swift
+++ b/TCAT/Controllers/ServiceAlertsViewController.swift
@@ -115,6 +115,8 @@ class ServiceAlertsViewController: UIViewController {
                     self.networkError = true
                     self.alerts = [:]
                     self.printClass(context: "\(#function) error", message: error.localizedDescription)
+                    let payload = NetworkErrorPayload(location: "\(self) \(#function)", type: "\((error as NSError).domain)", description: error.localizedDescription)
+                    Analytics.shared.log(payload)
                 }
             }
         })

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -132,16 +132,6 @@ struct RouteSharedEventPayload: Payload {
     let error: String?
 }
 
-/// Log any errors when calculating routes
-struct GetRoutesErrorPayload: Payload {
-    static let eventName: String = "Get Routes Error"
-    let deviceInfo = DeviceInfo()
-
-    let type: String
-    let description: String
-    let url: String?
-}
-
 /// Log any errors when sending feedback
 struct FeedbackErrorPayload: Payload {
     static let eventName: String = "Feedback Error"
@@ -219,12 +209,13 @@ struct WhatsNewCardDismissedPayload: Payload {
     let actionDescription: String
 }
 
-/// Log any networking error
-struct NetworkErrorPayload: Payload {
-    static let eventName: String = "Network Error"
+/// Log get errors
+struct GetErrorPayload: Payload {
+    static let eventName: String = "Get Error"
     let deviceInfo = DeviceInfo()
     
     let location: String
     let type: String 
     let description: String
+    let url: String?
 }

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -209,9 +209,9 @@ struct WhatsNewCardDismissedPayload: Payload {
     let actionDescription: String
 }
 
-/// Log get errors
-struct GetErrorPayload: Payload {
-    static let eventName: String = "Get Error"
+/// Log any network error
+struct NetworkErrorPayload: Payload {
+    static let eventName: String = "Network Error"
     let deviceInfo = DeviceInfo()
     
     let location: String

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -218,3 +218,13 @@ struct WhatsNewCardDismissedPayload: Payload {
 
     let actionDescription: String
 }
+
+/// Log any networking error
+struct NetworkErrorPayload: Payload {
+    static let eventName: String = "Network Error"
+    let deviceInfo = DeviceInfo()
+    
+    let location: String
+    let type: String 
+    let description: String
+}

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -217,5 +217,4 @@ struct GetErrorPayload: Payload {
     let location: String
     let type: String 
     let description: String
-    let url: String?
 }


### PR DESCRIPTION
## Overview
For most errors, we weren't really doing anything to them except printing them. This PR adds a payload to log errors to Firebase so we can have a better understanding of where errors occur.  

## Changes Made
Added a new payload called GetErrorPayload to log errors relating to getSomething.

**Question** 
Not sure if GetErrorPayload is a good name. I didn't go with NetworkErrorPayload since not all errors are actually network error. Lmk if there could be a better name

## Test Coverage
The app still runs 

## Related PRs or Issues
#306 
#171 
