### PR TITLE
[MTSA][Refactor reachability][Part 1/2] Add ReachabilityManager

### DIFF
--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0645397123789C0400A4ED81 /* RetainTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0645397023789C0400A4ED81 /* RetainTest.swift */; };
 		069676ED23738C1F004F7152 /* ReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069676EC23738C1F004F7152 /* ReachabilityManager.swift */; };
 		06C4EFD9236A755300D97117 /* AddFavoriteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C4EFD8236A755300D97117 /* AddFavoriteTableViewCell.swift */; };
 		222BDE16215C1CEE0040DD93 /* WhatsNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BDE15215C1CEE0040DD93 /* WhatsNewHeaderView.swift */; };
@@ -201,6 +202,7 @@
 
 /* Begin PBXFileReference section */
 		05362765A3FFE8B3AC21E499 /* Pods-TCATUITests.local.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCATUITests.local.xcconfig"; path = "Target Support Files/Pods-TCATUITests/Pods-TCATUITests.local.xcconfig"; sourceTree = "<group>"; };
+		0645397023789C0400A4ED81 /* RetainTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetainTest.swift; sourceTree = "<group>"; };
 		069676EC23738C1F004F7152 /* ReachabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityManager.swift; sourceTree = "<group>"; };
 		06C4EFD8236A755300D97117 /* AddFavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFavoriteTableViewCell.swift; sourceTree = "<group>"; };
 		1DD024FEFC067440B1903BA7 /* Pods-TCAT.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCAT.debug.xcconfig"; path = "Target Support Files/Pods-TCAT/Pods-TCAT.debug.xcconfig"; sourceTree = "<group>"; };
@@ -468,6 +470,7 @@
 			isa = PBXGroup;
 			children = (
 				449A7C8D1D80D0E80019300C /* TCATTests.swift */,
+				0645397023789C0400A4ED81 /* RetainTest.swift */,
 				449A7C8F1D80D0E80019300C /* Info.plist */,
 			);
 			path = TCATTests;
@@ -1204,6 +1207,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0645397123789C0400A4ED81 /* RetainTest.swift in Sources */,
 				449A7C8E1D80D0E80019300C /* TCATTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1407,7 +1411,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 47;
 				INFOPLIST_FILE = TCATTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cuappdev.TCATTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1668,7 +1672,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 47;
 				INFOPLIST_FILE = TCATTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cuappdev.TCATTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1825,7 +1829,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 47;
 				INFOPLIST_FILE = TCATTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cuappdev.TCATTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		069676ED23738C1F004F7152 /* ReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069676EC23738C1F004F7152 /* ReachabilityManager.swift */; };
 		06C4EFD9236A755300D97117 /* AddFavoriteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C4EFD8236A755300D97117 /* AddFavoriteTableViewCell.swift */; };
 		222BDE16215C1CEE0040DD93 /* WhatsNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BDE15215C1CEE0040DD93 /* WhatsNewHeaderView.swift */; };
 		22443222231871CD00987417 /* RouteDetailContentViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22443221231871CD00987417 /* RouteDetailContentViewController+Extensions.swift */; };
@@ -200,6 +201,7 @@
 
 /* Begin PBXFileReference section */
 		05362765A3FFE8B3AC21E499 /* Pods-TCATUITests.local.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCATUITests.local.xcconfig"; path = "Target Support Files/Pods-TCATUITests/Pods-TCATUITests.local.xcconfig"; sourceTree = "<group>"; };
+		069676EC23738C1F004F7152 /* ReachabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityManager.swift; sourceTree = "<group>"; };
 		06C4EFD8236A755300D97117 /* AddFavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFavoriteTableViewCell.swift; sourceTree = "<group>"; };
 		1DD024FEFC067440B1903BA7 /* Pods-TCAT.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCAT.debug.xcconfig"; path = "Target Support Files/Pods-TCAT/Pods-TCAT.debug.xcconfig"; sourceTree = "<group>"; };
 		222BDE15215C1CEE0040DD93 /* WhatsNewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WhatsNewHeaderView.swift; path = Views/WhatsNewHeaderView.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				BF250D7E222FB12300E7F271 /* Endpoints.swift */,
 				22948BFB221B75C5003FC43F /* Models.swift */,
 				DD3D9C201F94297100B164D4 /* Reachability.swift */,
+				069676EC23738C1F004F7152 /* ReachabilityManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1117,6 +1120,7 @@
 				502D8F5F1E55161D005280F1 /* SearchBarView.swift in Sources */,
 				5006F7BA1EC0F59A005ACAF2 /* SearchTableViewHelpers.swift in Sources */,
 				06C4EFD9236A755300D97117 /* AddFavoriteTableViewCell.swift in Sources */,
+				069676ED23738C1F004F7152 /* ReachabilityManager.swift in Sources */,
 				BFCA712D206AC69000E4CCE5 /* Keys.swift in Sources */,
 				22D76E8F2263E21F00FA21B9 /* HomeOptionsCardViewController.swift in Sources */,
 				C2240435231838C300095C5C /* PlaceCoordinates.swift in Sources */,

--- a/TCAT.xcodeproj/xcshareddata/xcschemes/TCATTests.xcscheme
+++ b/TCAT.xcodeproj/xcshareddata/xcschemes/TCATTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "449A7C881D80D0E80019300C"
+               BuildableName = "TCATTests.xctest"
+               BlueprintName = "TCATTests"
+               ReferencedContainer = "container:TCAT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TCAT/Network/Reachability.swift
+++ b/TCAT/Network/Reachability.swift
@@ -28,7 +28,7 @@ POSSIBILITY OF SUCH DAMAGE.
 import SystemConfiguration
 import Foundation
 
- enum ReachabilityError: Swift.Error {
+enum ReachabilityError: Swift.Error {
     case FailedToCreateWithAddress(sockaddr_in)
     case FailedToCreateWithHostname(String)
     case UnableToSetCallback

--- a/TCAT/Network/ReachabilityManager.swift
+++ b/TCAT/Network/ReachabilityManager.swift
@@ -16,7 +16,7 @@ class ReachabilityManager: NSObject {
     private var listeners: [Pair] = []
     
     typealias Listener = AnyObject
-    typealias Closure = (Reachability.Connection) -> ()
+    typealias Closure = (Reachability.Connection) -> Void
     
     private struct Pair {
         weak var listener: Listener?

--- a/TCAT/Network/ReachabilityManager.swift
+++ b/TCAT/Network/ReachabilityManager.swift
@@ -1,0 +1,45 @@
+//
+//  ReachabilityManager.swift
+//  TCAT
+//
+//  Created by Daniel Vebman on 11/6/19.
+//  Copyright © 2019 cuappdev. All rights reserved.
+//
+
+import Foundation
+
+class ReachabilityManager: NSObject {
+    static let shared: ReachabilityManager = ReachabilityManager()
+    
+    private let reachability = Reachability()
+    
+    typealias Listener = (Reachability.Connection) -> ()
+    private var listeners: [Listener] = []
+    
+    private override init() {
+        super.init()
+        
+        do {
+            try reachability?.startNotifier()
+        } catch {
+            printClass(context: "\(#function)", message: "Could not start reachability notifier.")
+        }
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reachabilityChanged(_:)),
+            name: .reachabilityChanged,
+            object: reachability
+        )
+    }
+    
+    func addListener(_ listener: @escaping Listener) {
+        listeners.append(listener)
+    }
+    
+    @objc func reachabilityChanged(_ notification: Notification) {
+        guard let reachability = reachability else { return }
+        listeners.forEach { $0(reachability.connection) }
+    }
+    
+}

--- a/TCATTests/RetainTest.swift
+++ b/TCATTests/RetainTest.swift
@@ -1,0 +1,55 @@
+//
+//  RetainTest.swift
+//  TCATTests
+//
+//  Created by Daniel Vebman on 11/10/19.
+//  Copyright © 2019 cuappdev. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class TestRetainVC: UIViewController {
+    let v = UIView()
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        
+        TestManager.shared.addListener(self) { [weak self] (s) in
+            self?.v.backgroundColor = .red
+            print("Recevied " + s)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class TestManager {
+    
+    static let shared = TestManager()
+    
+    private var listeners: [Pair] = []
+    
+    private struct Pair {
+        weak var listener: Listener?
+        var closure: Closure
+    }
+    typealias Listener = AnyObject
+    typealias Closure = (String) -> ()
+    
+    func addListener(_ listener: Listener, _ closure: @escaping Closure) {
+        listeners.append(Pair(listener: listener, closure: closure))
+    }
+    
+    func fire(_ s: String) {
+        listeners = listeners.filter { pair -> Bool in
+            pair.closure(s)
+            return pair.listener != nil
+        }
+        
+        print("*", listeners)
+    }
+    
+}

--- a/TCATTests/RetainTest.swift
+++ b/TCATTests/RetainTest.swift
@@ -10,12 +10,13 @@ import Foundation
 import UIKit
 
 class TestRetainVC: UIViewController {
+    
     let v = UIView()
     
     init() {
         super.init(nibName: nil, bundle: nil)
         
-        TestManager.shared.addListener(self) { [weak self] (s) in
+        TestManager.shared.addListener(self) { [weak self] s in
             self?.v.backgroundColor = .red
             print("Recevied " + s)
         }
@@ -24,6 +25,7 @@ class TestRetainVC: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
 }
 
 class TestManager {
@@ -37,7 +39,7 @@ class TestManager {
         var closure: Closure
     }
     typealias Listener = AnyObject
-    typealias Closure = (String) -> ()
+    typealias Closure = (String) -> Void
     
     func addListener(_ listener: Listener, _ closure: @escaping Closure) {
         listeners.append(Pair(listener: listener, closure: closure))

--- a/TCATTests/TCATTests.swift
+++ b/TCATTests/TCATTests.swift
@@ -7,18 +7,35 @@
 //
 
 import XCTest
-@testable import TCAT
 
 class TCATTests: XCTestCase {
+    
+    var vc: TestRetainVC?
     
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
+
     }
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+    }
+    
+    func testRetain() {
+        print("* Test retain...")
+        
+        vc = TestRetainVC()
+        
+        TestManager.shared.fire("* Hello")
+        TestManager.shared.fire("* Banana")
+        
+        vc = nil
+        
+        TestManager.shared.fire("* world")
+        
+        print("* Done.")
     }
     
     func testExample() {


### PR DESCRIPTION
## Overview

Currently, all reachability updates are passed down to child view controllers through a gross series of delegate method calls from the root UINavigationController. This PR and the next one replace that rather serpentine system with a singleton `ReachabilityManager` than any object can subscribe to for reachability updates.

## Changes Made

Added a static singleton reachability manager that holds weak references to listeners so they are automatically removed once deinitialized. 

## Test Coverage

Added a test to make sure that the weak references stuff was actually working.

## Next Steps

Refactor all references to Reachability so that they instead add a closure to the `ReachabilityManager`.

## Related PRs or Issues

Part of the continuing series, Make Transit Stable Again #340.

I think you guys get the point by now. Maybe I'll start omitting that line ^.