### PR TITLE
Add notification banner

### DIFF
--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		22D9599F2269AB1700D115EC /* ServiceAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D9599E2269AB1700D115EC /* ServiceAlert.swift */; };
 		22FD6E8922925EDA0053A174 /* InformationTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD6E8822925EDA0053A174 /* InformationTableHeaderView.swift */; };
 		30F148B4236F9F0500291AE2 /* NotificationToggleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F148B3236F9F0500291AE2 /* NotificationToggleTableViewCell.swift */; };
+		30F148BE237CA02F00291AE2 /* NotificationBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F148BD237CA02F00291AE2 /* NotificationBannerView.swift */; };
 		371F7516EDE896E8F926165F /* Pods_Today_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE1A6AF335384977A983BFF1 /* Pods_Today_Extension.framework */; };
 		4319AD3A2AF4CCF507164129 /* Pods_TCATTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BDD89B15CA2409469349E8C /* Pods_TCATTests.framework */; };
 		449A7C791D80D0E80019300C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449A7C781D80D0E80019300C /* AppDelegate.swift */; };
@@ -230,6 +231,7 @@
 		22FD6E8822925EDA0053A174 /* InformationTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InformationTableHeaderView.swift; path = Views/InformationTableHeaderView.swift; sourceTree = "<group>"; };
 		2F4B7F4D04B5E76C3C373607 /* Pods-TCAT.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCAT.release.xcconfig"; path = "Target Support Files/Pods-TCAT/Pods-TCAT.release.xcconfig"; sourceTree = "<group>"; };
 		30F148B3236F9F0500291AE2 /* NotificationToggleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToggleTableViewCell.swift; sourceTree = "<group>"; };
+		30F148BD237CA02F00291AE2 /* NotificationBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBannerView.swift; sourceTree = "<group>"; };
 		3BDD89B15CA2409469349E8C /* Pods_TCATTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TCATTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		411FF1B280B230ABFD3ED4AD /* Pods-TCATUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TCATUITests.release.xcconfig"; path = "Target Support Files/Pods-TCATUITests/Pods-TCATUITests.release.xcconfig"; sourceTree = "<group>"; };
 		449A7C751D80D0E80019300C /* TCAT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TCAT.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -644,6 +646,7 @@
 				BF5C52A3207B96F0003C93B9 /* LiveIndicator.swift */,
 				BF0002211FB37D0A00773109 /* LoadingIndicator.swift */,
 				BF316CAF2096352B005A14EF /* PhraseLabelFooterView.swift */,
+				30F148BD237CA02F00291AE2 /* NotificationBannerView.swift */,
 				22D76E902266CCC000FA21B9 /* RoundShadowedView.swift */,
 				BF2DA890224539DD006E527D /* RouteDiagram.swift */,
 				229BD4E6229792A90042D9D3 /* RouteDiagramSegment.swift */,
@@ -1191,6 +1194,7 @@
 				DDBFEAA01E787008002BBD96 /* DatePickerView.swift in Sources */,
 				DDC83CA51E52B0D400D4EDDF /* RouteTableViewCell.swift in Sources */,
 				DCB717101FB76EA600BE4D26 /* StopPickerViewController.swift in Sources */,
+				30F148BE237CA02F00291AE2 /* NotificationBannerView.swift in Sources */,
 				22D76E8E2263E21F00FA21B9 /* HomeMapViewController.swift in Sources */,
 				7EBD9D9E22263120008BF900 /* WalkWithDistanceIcon.swift in Sources */,
 				449A7C791D80D0E80019300C /* AppDelegate.swift in Sources */,

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -59,7 +59,7 @@ class RouteDetailDrawerViewController: UIViewController {
     private var busDelayNetworkTimer: Timer?
     private let chevronFlipDurationTime = 0.25
     private let networking: Networking = URLSession.shared.request
-    let route: Route
+    private let route: Route
 
     // MARK: - Initalization
     init(route: Route) {
@@ -240,6 +240,10 @@ class RouteDetailDrawerViewController: UIViewController {
 
     private func getDelay(tripId: String, stopId: String) -> Future<Response<Int?>> {
         return networking(Endpoint.getDelay(tripID: tripId, stopID: stopId)).decode()
+    }
+
+    func getFirstDirection() -> Direction? {
+        return route.directions.first(where: { $0.type == .depart })
     }
 
     /// Toggle the cell expansion at the indexPath

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import FutureNova
+import NotificationBannerSwift
 import Pulley
 import SwiftyJSON
 import UIKit
@@ -59,7 +60,9 @@ class RouteDetailDrawerViewController: UIViewController {
     private var busDelayNetworkTimer: Timer?
     private let chevronFlipDurationTime = 0.25
     private let networking: Networking = URLSession.shared.request
-    private var route: Route!
+    var route: Route!
+
+    var notificationBanner: FloatingNotificationBanner?
 
     // MARK: - Initalization
     init(route: Route) {

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import FutureNova
-import NotificationBannerSwift
 import Pulley
 import SwiftyJSON
 import UIKit

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -34,7 +34,7 @@ class RouteDetailDrawerViewController: UIViewController {
 
         case busStop(LocationObject)
         case direction(Direction)
-        case notificationTitle(String)
+        case notificationType(NotificationType)
 
         func getDirection() -> Direction? {
             switch self {
@@ -146,12 +146,12 @@ class RouteDetailDrawerViewController: UIViewController {
     }
 
     private func setupSections() {
-        let notificationTitles = [
-            RouteDetailItem.notificationTitle(Constants.Notification.notifyDelay),
-            RouteDetailItem.notificationTitle(Constants.Notification.notifyBeforeBoarding)
+        let notificationTypes = [
+            RouteDetailItem.notificationType(.delay),
+            RouteDetailItem.notificationType(.beforeBoarding)
         ]
 
-        let notificationSection = Section(type: .notification, items: notificationTitles)
+        let notificationSection = Section(type: .notification, items: notificationTypes)
         let routeDetailSection = Section(type: .routeDetail, items: directionsAndVisibleStops)
 
         sections = [routeDetailSection]

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -60,16 +60,14 @@ class RouteDetailDrawerViewController: UIViewController {
     private var busDelayNetworkTimer: Timer?
     private let chevronFlipDurationTime = 0.25
     private let networking: Networking = URLSession.shared.request
-    var route: Route!
-
-    var notificationBanner: FloatingNotificationBanner?
+    let route: Route
 
     // MARK: - Initalization
     init(route: Route) {
-        super.init(nibName: nil, bundle: nil)
         self.route = route
+        super.init(nibName: nil, bundle: nil)
         summaryView = SummaryView(route: route)
-        self.directionsAndVisibleStops = route.directions.map({ RouteDetailItem.direction($0) })
+        directionsAndVisibleStops = route.directions.map({ RouteDetailItem.direction($0) })
     }
 
     required convenience init(coder aDecoder: NSCoder) {

--- a/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
@@ -47,7 +47,7 @@ extension RouteDetailDrawerViewController: NotificationToggleTableViewDelegate {
         guard let direction = getFirstDirection() else { return }
         notificationBanner = FloatingNotificationBanner(
             customView: NotificationBannerView(
-                busAttachment: getBusIconImageAsTextAttachment(for: direction.routeNumber, notificationType: notificationType),
+                busAttachment: getBusIconImageAsTextAttachment(for: direction.routeNumber),
                 notificationType: notificationType
             )
         )
@@ -61,7 +61,7 @@ extension RouteDetailDrawerViewController: NotificationToggleTableViewDelegate {
         return firstDirection
     }
 
-    private func getBusIconImageAsTextAttachment(for busNumber: Int, notificationType: NotificationType) -> NSTextAttachment {
+    private func getBusIconImageAsTextAttachment(for busNumber: Int) -> NSTextAttachment {
         let busIconSpacingBetweenText: CGFloat = 5
 
         // Instantiate busIconView offScreen to later turn into UIImage

--- a/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
@@ -43,7 +43,7 @@ extension RouteDetailDrawerViewController: LargeDetailTableViewDelegate {
 
 extension RouteDetailDrawerViewController: NotificationToggleTableViewDelegate {
 
-    func displayNotificationBanner(type: NotificationType) {
+    func displayNotificationBanner(type: NotificationBannerType) {
         guard let direction = getFirstDirection() else { return }
         FloatingNotificationBanner(
             customView: NotificationBannerView(
@@ -76,12 +76,12 @@ extension RouteDetailDrawerViewController: NotificationToggleTableViewDelegate {
         // Create container to add padding on sides
         let containerView = UIView(frame: busIconFrame)
         containerView.isOpaque = false
+        view.addSubview(containerView)
         containerView.addSubview(busIconView)
         busIconView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(busIconTextSpacing)
             make.top.bottom.equalToSuperview()
         }
-        view.addSubview(containerView)
 
         // Create NSTextAttachment with the busIcon as a UIImage
         let iconAttachment = NSTextAttachment()
@@ -189,11 +189,11 @@ extension RouteDetailDrawerViewController: UITableViewDataSource {
                 )
                 return cell
             }
-        case .notificationTitle(let notificationTitle):
+        case .notificationType(let type):
             guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.Cells.notificationToggleCellIdentifier) as? NotificationToggleTableViewCell
                 else { return UITableViewCell() }
             cell.configure(
-                for: notificationTitle,
+                for: type,
                 isFirst: indexPath.row == 0,
                 delegate: self
             )

--- a/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
@@ -56,10 +56,6 @@ extension RouteDetailDrawerViewController: NotificationToggleTableViewDelegate {
         )
     }
 
-    private func getFirstDirection() -> Direction? {
-        return route.directions.first(where: { $0.type == .depart })
-    }
-
     private func getBusIconImageAsTextAttachment(for busNumber: Int) -> NSTextAttachment {
         let busIconTextSpacing: CGFloat = 5
 

--- a/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
@@ -43,34 +43,33 @@ extension RouteDetailDrawerViewController: LargeDetailTableViewDelegate {
 
 extension RouteDetailDrawerViewController: NotificationToggleTableViewDelegate {
 
-    func displayNotificationBanner(notificationType: NotificationType) {
+    func displayNotificationBanner(type: NotificationType) {
         guard let direction = getFirstDirection() else { return }
-        notificationBanner = FloatingNotificationBanner(
+        FloatingNotificationBanner(
             customView: NotificationBannerView(
                 busAttachment: getBusIconImageAsTextAttachment(for: direction.routeNumber),
-                notificationType: notificationType
+                type: type
             )
+        ).show(
+            queue: NotificationBannerQueue(maxBannersOnScreenSimultaneously: 1),
+            on: navigationController
         )
-        notificationBanner?.show(queue: NotificationBannerQueue(maxBannersOnScreenSimultaneously: 1), on: navigationController)
     }
 
     private func getFirstDirection() -> Direction? {
-        let firstDirection = route.directions.compactMap {
-            return $0.type == .depart ? $0 : nil
-        }.first
-        return firstDirection
+        return route.directions.first(where: { $0.type == .depart })
     }
 
     private func getBusIconImageAsTextAttachment(for busNumber: Int) -> NSTextAttachment {
-        let busIconSpacingBetweenText: CGFloat = 5
+        let busIconTextSpacing: CGFloat = 5
 
-        // Instantiate busIconView offScreen to later turn into UIImage
-        let busIconView = BusIcon(type: .lightSmallBlue, number: busNumber)
+        // Instantiate busIconView off screen to later turn into UIImage
+        let busIconView = BusIcon(type: .blueBannerSmall, number: busNumber)
 
         let busIconFrame = CGRect(
             x: 0,
             y: 0,
-            width: busIconView.intrinsicContentSize.width + busIconSpacingBetweenText * 2,
+            width: busIconView.intrinsicContentSize.width + busIconTextSpacing * 2,
             height: busIconView.intrinsicContentSize.height
         )
 
@@ -79,7 +78,7 @@ extension RouteDetailDrawerViewController: NotificationToggleTableViewDelegate {
         containerView.isOpaque = false
         containerView.addSubview(busIconView)
         busIconView.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(busIconSpacingBetweenText)
+            make.leading.trailing.equalToSuperview().inset(busIconTextSpacing)
             make.top.bottom.equalToSuperview()
         }
         view.addSubview(containerView)

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -23,40 +23,38 @@ enum NotificationType {
 
 }
 
-class NotificationBannerView: RoundShadowedView {
+class NotificationBannerView: UIView {
 
     private var type: NotificationType
 
+    private let shadowedView = RoundShadowedView(cornerRadius: 10)
     private let notificationLabel = UILabel()
 
-    init(busAttachment: NSTextAttachment, notificationType: NotificationType) {
-        let cornerRadius: CGFloat = 10
+    init(busAttachment: NSTextAttachment, type: NotificationType) {
 
-        self.type = notificationType
-        super.init(cornerRadius: cornerRadius)
+        self.type = type
+        super.init(frame: .zero)
 
-        layer.shadowOpacity = 0.8
+        shadowedView.setColor(color: type.bannerColor)
+        shadowedView.layer.shadowOpacity = 0.8
+        addSubview(shadowedView)
 
-        containerView.backgroundColor = type.bannerColor
-
-        notificationLabel.attributedText = formatTitleLabel(attachment: busAttachment)
+        notificationLabel.attributedText = getNotificationLabelAttributedString(attachment: busAttachment)
         notificationLabel.font = .getFont(.regular, size: 14)
         notificationLabel.textColor = Colors.white
         notificationLabel.lineBreakMode = .byWordWrapping
         notificationLabel.numberOfLines = 0
-        containerView.addSubview(notificationLabel)
-        
+        shadowedView.addSubview(notificationLabel)
+
         setupConstraints()
     }
 
     private func setupConstraints() {
-        let containerViewInset = 8
         let notificationLabelInset = 15
-        let topPadding = 5
+        let shadowedViewInset = 6
 
-        containerView.snp.remakeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(containerViewInset)
-            make.top.equalToSuperview().inset(topPadding)
+        shadowedView.snp.makeConstraints { make in
+            make.leading.trailing.top.equalToSuperview().inset(shadowedViewInset)
         }
 
         notificationLabel.snp.makeConstraints { make in
@@ -64,17 +62,15 @@ class NotificationBannerView: RoundShadowedView {
         }
     }
 
-    private func formatTitleLabel(attachment: NSTextAttachment) -> NSMutableAttributedString {
- 
-        var beginningText: String {
-            switch type {
-            case .beforeBoardingConfirmation:
-                return Constants.Notification.beforeBoardingConfirmation
-            case .delayConfirmation:
-                return Constants.Notification.delayConfirmation
-            default:
-                return ""
-            }
+    private func getNotificationLabelAttributedString(attachment: NSTextAttachment) -> NSAttributedString {
+        var beginningText: String
+        switch type {
+        case .beforeBoardingConfirmation:
+            beginningText = Constants.Notification.beforeBoardingConfirmation
+        case .delayConfirmation:
+            beginningText = Constants.Notification.delayConfirmation
+        default:
+            beginningText = ""
         }
 
         let notificationText = NSMutableAttributedString(string: beginningText)

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -54,7 +54,7 @@ class NotificationBannerView: RoundShadowedView {
         let notificationLabelInset = 15
         let topPadding = 5
 
-        containerView.snp.remakeConstraints { (make) in
+        containerView.snp.remakeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(containerViewInset)
             make.top.equalToSuperview().inset(topPadding)
         }

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -9,9 +9,24 @@
 import UIKit
 
 enum NotificationType {
-    
+
+    case beforeBoarding, delay
+
+    var title: String {
+        switch self {
+        case .beforeBoarding:
+            return Constants.Notification.notifyBeforeBoarding
+        case .delay:
+            return Constants.Notification.notifyDelay
+        }
+    }
+
+}
+
+enum NotificationBannerType {
+
     case beforeBoardingConfirmation, busArriving, busDelay, delayConfirmation
-    
+
     var bannerColor: UIColor {
         switch self {
         case .beforeBoardingConfirmation, .busArriving, .delayConfirmation:
@@ -25,12 +40,12 @@ enum NotificationType {
 
 class NotificationBannerView: UIView {
 
-    private let type: NotificationType
+    private let type: NotificationBannerType
 
     private let notificationLabel = UILabel()
     private let shadowedView = RoundShadowedView(cornerRadius: 10)
 
-    init(busAttachment: NSTextAttachment, type: NotificationType) {
+    init(busAttachment: NSTextAttachment, type: NotificationBannerType) {
         self.type = type
         super.init(frame: .zero)
 

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -8,12 +8,11 @@
 
 import UIKit
 
-
 enum NotificationType {
     
     case beforeBoardingConfirmation, busArriving, busDelay, delayConfirmation
     
-    var color: UIColor {
+    var bannerColor: UIColor {
         switch self {
         case .beforeBoardingConfirmation, .busArriving, .delayConfirmation:
             return Colors.tcatBlue
@@ -21,56 +20,70 @@ enum NotificationType {
             return Colors.lateRed
         }
     }
-    
-    var title: String {
-        switch self {
-        case .beforeBoardingConfirmation:
-            return Constants.Notification.beforeBoardingConfirmation
-        case .delayConfirmation:
-            return Constants.Notification.delayConfirmation
-        case .busArriving:
-            return Constants.Notification.arrivalNotification
-        case .busDelay:
-            return Constants.Notification.delayNotification
-        }
-    }
+
 }
 
 class NotificationBannerView: RoundShadowedView {
-    
+
     private var type: NotificationType
 
     private let notificationLabel = UILabel()
-    
-    init(notificationType: NotificationType) {
+
+    init(busAttachment: NSTextAttachment, notificationType: NotificationType) {
         let cornerRadius: CGFloat = 10
-        
+
         self.type = notificationType
         super.init(cornerRadius: cornerRadius)
-        
-        layer.shadowOpacity = 1
 
-        containerView.backgroundColor = type.color
-        
-        notificationLabel.text = type.title
-        notificationLabel.textColor = Colors.white
+        layer.shadowOpacity = 0.8
+
+        containerView.backgroundColor = type.bannerColor
+
+        notificationLabel.attributedText = formatTitleLabel(attachment: busAttachment)
         notificationLabel.font = .getFont(.regular, size: 14)
+        notificationLabel.textColor = Colors.white
+        notificationLabel.lineBreakMode = .byWordWrapping
+        notificationLabel.numberOfLines = 0
         containerView.addSubview(notificationLabel)
         
         setupConstraints()
     }
-    
+
     private func setupConstraints() {
+        let containerViewInset = 8
         let notificationLabelInset = 15
-        
+        let topPadding = 5
+
         containerView.snp.remakeConstraints { (make) in
-            make.top.leading.trailing.equalToSuperview().inset(8)
-            make.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(containerViewInset)
+            make.top.equalToSuperview().inset(topPadding)
         }
-        
+
         notificationLabel.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(notificationLabelInset)
+            make.leading.trailing.equalToSuperview().inset(notificationLabelInset)
+            make.top.bottom.equalToSuperview().inset(notificationLabelInset)
         }
+    }
+
+    private func formatTitleLabel(attachment: NSTextAttachment) -> NSMutableAttributedString {
+ 
+        var beginningText: String {
+            switch type {
+            case .beforeBoardingConfirmation:
+                return Constants.Notification.beforeBoardingConfirmation
+            case .delayConfirmation:
+                return Constants.Notification.delayConfirmation
+            case .busArriving, .busDelay:
+                return ""
+            }
+        }
+
+        let notificationText = NSMutableAttributedString(string: beginningText)
+        if type == .delayConfirmation {
+            notificationText.append(NSAttributedString(attachment: attachment))
+        }
+
+        return notificationText
     }
     
     required init?(coder: NSCoder) {

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -100,5 +100,3 @@ class NotificationBannerView: UIView {
     }
     
 }
-
-

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -1,0 +1,82 @@
+//
+//  NotificationBannerView.swift
+//  TCAT
+//
+//  Created by HAIYING WENG on 11/13/19.
+//  Copyright © 2019 cuappdev. All rights reserved.
+//
+
+import UIKit
+
+
+enum NotificationType {
+    
+    case beforeBoardingConfirmation, busArriving, busDelay, delayConfirmation
+    
+    var color: UIColor {
+        switch self {
+        case .beforeBoardingConfirmation, .busArriving, .delayConfirmation:
+            return Colors.tcatBlue
+        case .busDelay:
+            return Colors.lateRed
+        }
+    }
+    
+    var title: String {
+        switch self {
+        case .beforeBoardingConfirmation:
+            return Constants.Notification.beforeBoardingConfirmation
+        case .delayConfirmation:
+            return Constants.Notification.delayConfirmation
+        case .busArriving:
+            return Constants.Notification.arrivalNotification
+        case .busDelay:
+            return Constants.Notification.delayNotification
+        }
+    }
+}
+
+class NotificationBannerView: RoundShadowedView {
+    
+    private var type: NotificationType
+
+    private let notificationLabel = UILabel()
+    
+    init(notificationType: NotificationType) {
+        let cornerRadius: CGFloat = 10
+        
+        self.type = notificationType
+        super.init(cornerRadius: cornerRadius)
+        
+        layer.shadowOpacity = 1
+
+        containerView.backgroundColor = type.color
+        
+        notificationLabel.text = type.title
+        notificationLabel.textColor = Colors.white
+        notificationLabel.font = .getFont(.regular, size: 14)
+        containerView.addSubview(notificationLabel)
+        
+        setupConstraints()
+    }
+    
+    private func setupConstraints() {
+        let notificationLabelInset = 15
+        
+        containerView.snp.remakeConstraints { (make) in
+            make.top.leading.trailing.equalToSuperview().inset(8)
+            make.bottom.equalToSuperview()
+        }
+        
+        notificationLabel.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(notificationLabelInset)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -25,10 +25,10 @@ enum NotificationType {
 
 class NotificationBannerView: UIView {
 
-    private var type: NotificationType
+    private let type: NotificationType
 
-    private let shadowedView = RoundShadowedView(cornerRadius: 10)
     private let notificationLabel = UILabel()
+    private let shadowedView = RoundShadowedView(cornerRadius: 10)
 
     init(busAttachment: NSTextAttachment, type: NotificationType) {
 
@@ -53,12 +53,12 @@ class NotificationBannerView: UIView {
         let notificationLabelInset = 15
         let shadowedViewInset = 6
 
-        shadowedView.snp.makeConstraints { make in
-            make.leading.trailing.top.equalToSuperview().inset(shadowedViewInset)
-        }
-
         notificationLabel.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(notificationLabelInset)
+        }
+
+        shadowedView.snp.makeConstraints { make in
+            make.leading.trailing.top.equalToSuperview().inset(shadowedViewInset)
         }
     }
 

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -31,7 +31,6 @@ class NotificationBannerView: UIView {
     private let shadowedView = RoundShadowedView(cornerRadius: 10)
 
     init(busAttachment: NSTextAttachment, type: NotificationType) {
-
         self.type = type
         super.init(frame: .zero)
 

--- a/TCAT/NotificationBannerView.swift
+++ b/TCAT/NotificationBannerView.swift
@@ -60,8 +60,7 @@ class NotificationBannerView: RoundShadowedView {
         }
 
         notificationLabel.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(notificationLabelInset)
-            make.top.bottom.equalToSuperview().inset(notificationLabelInset)
+            make.edges.equalToSuperview().inset(notificationLabelInset)
         }
     }
 
@@ -73,7 +72,7 @@ class NotificationBannerView: RoundShadowedView {
                 return Constants.Notification.beforeBoardingConfirmation
             case .delayConfirmation:
                 return Constants.Notification.delayConfirmation
-            case .busArriving, .busDelay:
+            default:
                 return ""
             }
         }

--- a/TCAT/NotificationToggleTableViewCell.swift
+++ b/TCAT/NotificationToggleTableViewCell.swift
@@ -9,14 +9,14 @@
 import UIKit
 
 protocol NotificationToggleTableViewDelegate: class {
-    func displayNotificationBanner(type: NotificationType)
+    func displayNotificationBanner(type: NotificationBannerType)
 }
 
 class NotificationToggleTableViewCell: UITableViewCell {
     
     private weak var delegate: NotificationToggleTableViewDelegate?
     
-    private var title = ""
+    private var type: NotificationType!
 
     private let firstHairline = UIView()
     private let hairline = UIView()
@@ -77,10 +77,10 @@ class NotificationToggleTableViewCell: UITableViewCell {
         }
     }
 
-    func configure(for notificationTitle: String, isFirst: Bool, delegate: NotificationToggleTableViewDelegate? = nil) {
+    func configure(for type: NotificationType, isFirst: Bool, delegate: NotificationToggleTableViewDelegate? = nil) {
         self.delegate = delegate
-        title = notificationTitle
-        notificationTitleLabel.text = notificationTitle
+        self.type = type
+        notificationTitleLabel.text = type.title
         if isFirst {
             setupFirstHairline()
         }
@@ -88,10 +88,12 @@ class NotificationToggleTableViewCell: UITableViewCell {
     
     @objc func switchValueChanged() {
         if notificationSwitch.isOn {
-            if title == Constants.Notification.notifyBeforeBoarding {
-                delegate?.displayNotificationBanner(type: NotificationType.beforeBoardingConfirmation)
-            } else {
-                delegate?.displayNotificationBanner(type: NotificationType.delayConfirmation)
+            switch type {
+            case .beforeBoarding:
+                delegate?.displayNotificationBanner(type: NotificationBannerType.beforeBoardingConfirmation)
+            case .delay:
+                delegate?.displayNotificationBanner(type: NotificationBannerType.delayConfirmation)
+            default: break
             }
         }
     }

--- a/TCAT/NotificationToggleTableViewCell.swift
+++ b/TCAT/NotificationToggleTableViewCell.swift
@@ -10,7 +10,7 @@ import NotificationBannerSwift
 import UIKit
 
 protocol NotificationToggleTableViewDelegate: class {
-    func displayNotificationBanner(notificationType: NotificationType)
+    func displayNotificationBanner(type: NotificationType)
 }
 
 class NotificationToggleTableViewCell: UITableViewCell {
@@ -91,9 +91,9 @@ class NotificationToggleTableViewCell: UITableViewCell {
     @objc func switchValueChanged() {
         if notificationSwitch.isOn {
             if title == Constants.Notification.notifyBeforeBoarding {
-                delegate?.displayNotificationBanner(notificationType: NotificationType.beforeBoardingConfirmation)
+                delegate?.displayNotificationBanner(type: NotificationType.beforeBoardingConfirmation)
             } else {
-                delegate?.displayNotificationBanner(notificationType: NotificationType.delayConfirmation)
+                delegate?.displayNotificationBanner(type: NotificationType.delayConfirmation)
             }
         }
     }

--- a/TCAT/NotificationToggleTableViewCell.swift
+++ b/TCAT/NotificationToggleTableViewCell.swift
@@ -6,9 +6,12 @@
 //  Copyright © 2019 cuappdev. All rights reserved.
 //
 
+import NotificationBannerSwift
 import UIKit
 
 class NotificationToggleTableViewCell: UITableViewCell {
+    
+    private var title = ""
 
     private let firstHairline = UIView()
     private let hairline = UIView()
@@ -16,6 +19,8 @@ class NotificationToggleTableViewCell: UITableViewCell {
     private let notificationTitleLabel = UILabel()
 
     private let hairlineHeight = 0.5
+    
+    private var notificationBanner: NotificationBanner?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -27,6 +32,7 @@ class NotificationToggleTableViewCell: UITableViewCell {
 
         notificationSwitch.onTintColor = Colors.tcatBlue
         notificationSwitch.transform = CGAffineTransform(scaleX: 0.75, y: 0.75)
+        notificationSwitch.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
         contentView.addSubview(notificationSwitch)
 
         notificationTitleLabel.font = .getFont(.regular, size: 14)
@@ -69,9 +75,22 @@ class NotificationToggleTableViewCell: UITableViewCell {
     }
 
     func configure(for notificationTitle: String, isFirst: Bool) {
+        title = notificationTitle
         notificationTitleLabel.text = notificationTitle
         if isFirst {
             setupFirstHairline()
+        }
+    }
+    
+    @objc func switchValueChanged() {
+        if notificationSwitch.isOn {
+            if title == Constants.Notification.notifyDelay {
+                notificationBanner = NotificationBanner(customView: NotificationBannerView(notificationType: NotificationType.delayConfirmation))
+            } else {
+                notificationBanner = NotificationBanner(customView: NotificationBannerView(notificationType: NotificationType.beforeBoardingConfirmation))
+            }
+            notificationBanner?.bannerHeight = 100
+            notificationBanner?.show()
         }
     }
 

--- a/TCAT/NotificationToggleTableViewCell.swift
+++ b/TCAT/NotificationToggleTableViewCell.swift
@@ -90,9 +90,9 @@ class NotificationToggleTableViewCell: UITableViewCell {
         if notificationSwitch.isOn {
             switch type {
             case .beforeBoarding:
-                delegate?.displayNotificationBanner(type: NotificationBannerType.beforeBoardingConfirmation)
+                delegate?.displayNotificationBanner(type: .beforeBoardingConfirmation)
             case .delay:
-                delegate?.displayNotificationBanner(type: NotificationBannerType.delayConfirmation)
+                delegate?.displayNotificationBanner(type: .delayConfirmation)
             default: break
             }
         }

--- a/TCAT/NotificationToggleTableViewCell.swift
+++ b/TCAT/NotificationToggleTableViewCell.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2019 cuappdev. All rights reserved.
 //
 
-import NotificationBannerSwift
 import UIKit
 
 protocol NotificationToggleTableViewDelegate: class {
@@ -21,7 +20,6 @@ class NotificationToggleTableViewCell: UITableViewCell {
 
     private let firstHairline = UIView()
     private let hairline = UIView()
-    private var notificationBanner: NotificationBanner?
     private let notificationSwitch = UISwitch()
     private let notificationTitleLabel = UILabel()
 

--- a/TCAT/NotificationToggleTableViewCell.swift
+++ b/TCAT/NotificationToggleTableViewCell.swift
@@ -9,18 +9,23 @@
 import NotificationBannerSwift
 import UIKit
 
+protocol NotificationToggleTableViewDelegate: class {
+    func displayNotificationBanner(notificationType: NotificationType)
+}
+
 class NotificationToggleTableViewCell: UITableViewCell {
+    
+    private weak var delegate: NotificationToggleTableViewDelegate?
     
     private var title = ""
 
     private let firstHairline = UIView()
     private let hairline = UIView()
+    private var notificationBanner: NotificationBanner?
     private let notificationSwitch = UISwitch()
     private let notificationTitleLabel = UILabel()
 
     private let hairlineHeight = 0.5
-    
-    private var notificationBanner: NotificationBanner?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -74,7 +79,8 @@ class NotificationToggleTableViewCell: UITableViewCell {
         }
     }
 
-    func configure(for notificationTitle: String, isFirst: Bool) {
+    func configure(for notificationTitle: String, isFirst: Bool, delegate: NotificationToggleTableViewDelegate? = nil) {
+        self.delegate = delegate
         title = notificationTitle
         notificationTitleLabel.text = notificationTitle
         if isFirst {
@@ -84,13 +90,11 @@ class NotificationToggleTableViewCell: UITableViewCell {
     
     @objc func switchValueChanged() {
         if notificationSwitch.isOn {
-            if title == Constants.Notification.notifyDelay {
-                notificationBanner = NotificationBanner(customView: NotificationBannerView(notificationType: NotificationType.delayConfirmation))
+            if title == Constants.Notification.notifyBeforeBoarding {
+                delegate?.displayNotificationBanner(notificationType: NotificationType.beforeBoardingConfirmation)
             } else {
-                notificationBanner = NotificationBanner(customView: NotificationBannerView(notificationType: NotificationType.beforeBoardingConfirmation))
+                delegate?.displayNotificationBanner(notificationType: NotificationType.delayConfirmation)
             }
-            notificationBanner?.bannerHeight = 100
-            notificationBanner?.show()
         }
     }
 

--- a/TCAT/Supporting Files/Constants.swift
+++ b/TCAT/Supporting Files/Constants.swift
@@ -240,12 +240,12 @@ struct Constants {
     }
     
     struct Notification {
+        static let arrivalNotification = "is arriving "
         static let beforeBoardingConfirmation = "You will receive notifications 10 min before boarding time"
         static let delayConfirmation = "You will receive notifications for delays in"
+        static let delayNotification = "has been delayed to "
         static let notifyBeforeBoarding = "Notify me 10 min before boarding"
         static let notifyDelay = "Notify me about delays"
-        static let delayNotification = "has been delayed to "
-        static let arrivalNotification = "is arriving "
     }
 
     struct SearchBar {

--- a/TCAT/Supporting Files/Constants.swift
+++ b/TCAT/Supporting Files/Constants.swift
@@ -244,8 +244,8 @@ struct Constants {
         static let delayConfirmation = "You will receive notifications for delays in"
         static let notifyBeforeBoarding = "Notify me 10 min before boarding"
         static let notifyDelay = "Notify me about delays"
-        static let delayNotification = "has been delayed to"
-        static let arrivalNotification = "is arriving at"
+        static let delayNotification = "has been delayed to "
+        static let arrivalNotification = "is arriving "
     }
 
     struct SearchBar {

--- a/TCAT/Supporting Files/Constants.swift
+++ b/TCAT/Supporting Files/Constants.swift
@@ -240,10 +240,10 @@ struct Constants {
     }
     
     struct Notification {
-        static let arrivalNotification = "is arriving "
+        static let arrivalNotification = "is arriving"
         static let beforeBoardingConfirmation = "You will receive notifications 10 min before boarding time"
         static let delayConfirmation = "You will receive notifications for delays in"
-        static let delayNotification = "has been delayed to "
+        static let delayNotification = "has been delayed to"
         static let notifyBeforeBoarding = "Notify me 10 min before boarding"
         static let notifyDelay = "Notify me about delays"
     }

--- a/TCAT/Supporting Files/Constants.swift
+++ b/TCAT/Supporting Files/Constants.swift
@@ -244,6 +244,8 @@ struct Constants {
         static let delayConfirmation = "You will receive notifications for delays in"
         static let notifyBeforeBoarding = "Notify me 10 min before boarding"
         static let notifyDelay = "Notify me about delays"
+        static let delayNotification = "has been delayed to"
+        static let arrivalNotification = "is arriving at"
     }
 
     struct SearchBar {

--- a/TCAT/Views/BusIcon.swift
+++ b/TCAT/Views/BusIcon.swift
@@ -47,10 +47,10 @@ enum BusIconType: String {
     
     var baseColor: UIColor {
         switch self {
-        case .directionLarge, .directionSmall, .liveTracking:
-            return Colors.tcatBlue
         case .blueBannerSmall, .redBannerSmall:
             return Colors.white
+        case .directionLarge, .directionSmall, .liveTracking:
+            return Colors.tcatBlue
         }
     }
     

--- a/TCAT/Views/BusIcon.swift
+++ b/TCAT/Views/BusIcon.swift
@@ -9,12 +9,12 @@ import UIKit
 
 enum BusIconType: String {
 
-    case directionSmall, directionLarge, liveTracking
+    case directionSmall, directionLarge, lightSmallBlue, lightSmallRed, liveTracking
 
     /// Return BusIcon's frame width
     var width: CGFloat {
         switch self {
-        case .directionSmall:
+        case .directionSmall, .lightSmallBlue, .lightSmallRed:
             return 48
         case .liveTracking:
             return 72
@@ -26,7 +26,7 @@ enum BusIconType: String {
     /// Return BusIcon's frame height
     var height: CGFloat {
         switch self {
-        case .directionSmall:
+        case .directionSmall, .lightSmallBlue, .lightSmallRed:
             return 24
         case .liveTracking:
             return 30
@@ -42,6 +42,26 @@ enum BusIconType: String {
             return 8
         default:
             return 4
+        }
+    }
+    
+    var baseColor: UIColor {
+        switch self {
+        case .directionSmall, .directionLarge, .liveTracking:
+            return Colors.tcatBlue
+        case .lightSmallBlue, .lightSmallRed:
+            return Colors.white
+        }
+    }
+    
+    var contentColor: UIColor {
+        switch self {
+        case .directionSmall, .directionLarge, .liveTracking:
+            return Colors.white
+        case .lightSmallBlue:
+            return Colors.tcatBlue
+        case .lightSmallRed:
+            return Colors.lateRed
         }
     }
 
@@ -68,7 +88,7 @@ class BusIcon: UIView {
 
         var fontSize: CGFloat
         switch type {
-        case .directionSmall: fontSize = 14
+        case .directionSmall, .lightSmallBlue, .lightSmallRed: fontSize = 14
         case .directionLarge: fontSize = 20
         case .liveTracking: fontSize = 16
         }
@@ -76,21 +96,21 @@ class BusIcon: UIView {
         backgroundColor = .clear
         isOpaque = false
 
-        baseView.backgroundColor = Colors.tcatBlue
+        baseView.backgroundColor = type.baseColor
         baseView.layer.cornerRadius = type.cornerRadius
         addSubview(baseView)
 
-        image.tintColor = Colors.white
+        image.tintColor = type.contentColor
         addSubview(image)
 
         label.text = "\(number)"
         label.font = .getFont(.semibold, size: fontSize)
-        label.textColor = Colors.white
+        label.textColor = type.contentColor
         label.textAlignment = .center
         addSubview(label)
 
         if type == .liveTracking {
-            liveIndicator = LiveIndicator(size: .large, color: Colors.white)
+            liveIndicator = LiveIndicator(size: .large, color: type.contentColor)
             addSubview(liveIndicator!)
         }
 
@@ -103,7 +123,7 @@ class BusIcon: UIView {
         var constant: CGFloat
         switch type {
         case .liveTracking: constant = 0.87
-        case .directionSmall: constant = 0.75
+        case .directionSmall, .lightSmallRed, .lightSmallBlue: constant = 0.75
         case .directionLarge: constant = 1
         }
         let imageSize = CGSize(width: image.frame.width * constant, height: image.frame.height * constant)

--- a/TCAT/Views/BusIcon.swift
+++ b/TCAT/Views/BusIcon.swift
@@ -123,7 +123,7 @@ class BusIcon: UIView {
         var constant: CGFloat
         switch type {
         case .liveTracking: constant = 0.87
-        case .directionSmall, .lightSmallRed, .lightSmallBlue: constant = 0.75
+        case .directionSmall, .lightSmallBlue, .lightSmallRed: constant = 0.75
         case .directionLarge: constant = 1
         }
         let imageSize = CGSize(width: image.frame.width * constant, height: image.frame.height * constant)

--- a/TCAT/Views/BusIcon.swift
+++ b/TCAT/Views/BusIcon.swift
@@ -9,16 +9,16 @@ import UIKit
 
 enum BusIconType: String {
 
-    case blueBannerSmall, directionSmall, directionLarge, redBannerSmall, liveTracking
+    case blueBannerSmall, directionLarge, directionSmall, liveTracking, redBannerSmall
 
     /// Return BusIcon's frame width
     var width: CGFloat {
         switch self {
-        case .directionSmall, .blueBannerSmall, .redBannerSmall:
+        case .blueBannerSmall, .directionSmall, .redBannerSmall:
             return 48
-        case .liveTracking:
-            return 72
         case .directionLarge:
+            return 72
+        case .liveTracking:
             return 72
         }
     }
@@ -26,12 +26,12 @@ enum BusIconType: String {
     /// Return BusIcon's frame height
     var height: CGFloat {
         switch self {
-        case .directionSmall, .blueBannerSmall, .redBannerSmall:
+        case .blueBannerSmall, .directionSmall, .redBannerSmall:
             return 24
-        case .liveTracking:
-            return 30
         case .directionLarge:
             return 36
+        case .liveTracking:
+            return 30
         }
     }
 
@@ -47,7 +47,7 @@ enum BusIconType: String {
     
     var baseColor: UIColor {
         switch self {
-        case .directionSmall, .directionLarge, .liveTracking:
+        case .directionLarge, .directionSmall, .liveTracking:
             return Colors.tcatBlue
         case .blueBannerSmall, .redBannerSmall:
             return Colors.white
@@ -56,10 +56,10 @@ enum BusIconType: String {
     
     var contentColor: UIColor {
         switch self {
-        case .directionSmall, .directionLarge, .liveTracking:
-            return Colors.white
         case .blueBannerSmall:
             return Colors.tcatBlue
+        case .directionLarge, .directionSmall, .liveTracking:
+            return Colors.white
         case .redBannerSmall:
             return Colors.lateRed
         }
@@ -88,7 +88,7 @@ class BusIcon: UIView {
 
         var fontSize: CGFloat
         switch type {
-        case .directionSmall, .blueBannerSmall, .redBannerSmall: fontSize = 14
+        case .blueBannerSmall, .directionSmall, .redBannerSmall: fontSize = 14
         case .directionLarge: fontSize = 20
         case .liveTracking: fontSize = 16
         }
@@ -122,9 +122,9 @@ class BusIcon: UIView {
 
         var constant: CGFloat
         switch type {
-        case .liveTracking: constant = 0.87
-        case .directionSmall, .blueBannerSmall, .redBannerSmall: constant = 0.75
+        case .blueBannerSmall, .directionSmall, .redBannerSmall: constant = 0.75
         case .directionLarge: constant = 1
+        case .liveTracking: constant = 0.87
         }
         let imageSize = CGSize(width: image.frame.width * constant, height: image.frame.height * constant)
 

--- a/TCAT/Views/BusIcon.swift
+++ b/TCAT/Views/BusIcon.swift
@@ -9,12 +9,12 @@ import UIKit
 
 enum BusIconType: String {
 
-    case directionSmall, directionLarge, lightSmallBlue, lightSmallRed, liveTracking
+    case blueBannerSmall, directionSmall, directionLarge, redBannerSmall, liveTracking
 
     /// Return BusIcon's frame width
     var width: CGFloat {
         switch self {
-        case .directionSmall, .lightSmallBlue, .lightSmallRed:
+        case .directionSmall, .blueBannerSmall, .redBannerSmall:
             return 48
         case .liveTracking:
             return 72
@@ -26,7 +26,7 @@ enum BusIconType: String {
     /// Return BusIcon's frame height
     var height: CGFloat {
         switch self {
-        case .directionSmall, .lightSmallBlue, .lightSmallRed:
+        case .directionSmall, .blueBannerSmall, .redBannerSmall:
             return 24
         case .liveTracking:
             return 30
@@ -49,7 +49,7 @@ enum BusIconType: String {
         switch self {
         case .directionSmall, .directionLarge, .liveTracking:
             return Colors.tcatBlue
-        case .lightSmallBlue, .lightSmallRed:
+        case .blueBannerSmall, .redBannerSmall:
             return Colors.white
         }
     }
@@ -58,9 +58,9 @@ enum BusIconType: String {
         switch self {
         case .directionSmall, .directionLarge, .liveTracking:
             return Colors.white
-        case .lightSmallBlue:
+        case .blueBannerSmall:
             return Colors.tcatBlue
-        case .lightSmallRed:
+        case .redBannerSmall:
             return Colors.lateRed
         }
     }
@@ -88,7 +88,7 @@ class BusIcon: UIView {
 
         var fontSize: CGFloat
         switch type {
-        case .directionSmall, .lightSmallBlue, .lightSmallRed: fontSize = 14
+        case .directionSmall, .blueBannerSmall, .redBannerSmall: fontSize = 14
         case .directionLarge: fontSize = 20
         case .liveTracking: fontSize = 16
         }
@@ -123,7 +123,7 @@ class BusIcon: UIView {
         var constant: CGFloat
         switch type {
         case .liveTracking: constant = 0.87
-        case .directionSmall, .lightSmallBlue, .lightSmallRed: constant = 0.75
+        case .directionSmall, .blueBannerSmall, .redBannerSmall: constant = 0.75
         case .directionLarge: constant = 1
         }
         let imageSize = CGSize(width: image.frame.width * constant, height: image.frame.height * constant)

--- a/TCAT/Views/RoundShadowedView.swift
+++ b/TCAT/Views/RoundShadowedView.swift
@@ -30,7 +30,7 @@ class RoundShadowedView: UIView {
 
         addSubview(containerView)
 
-        containerView.snp.makeConstraints { (make) in
+        containerView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
     }

--- a/TCAT/Views/RoundShadowedView.swift
+++ b/TCAT/Views/RoundShadowedView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class RoundShadowedView: UIView {
 
-    var containerView: UIView!
+    private let containerView = UIView()
 
     init(cornerRadius: CGFloat) {
         super.init(frame: .zero)
@@ -22,7 +22,6 @@ class RoundShadowedView: UIView {
         layer.shadowOpacity = 0.4
         layer.shadowRadius = cornerRadius / 4
 
-        containerView = UIView()
         containerView.backgroundColor = .white
 
         containerView.layer.cornerRadius = cornerRadius
@@ -41,6 +40,10 @@ class RoundShadowedView: UIView {
         } else {
             containerView.addSubview(view)
         }
+    }
+
+    func setColor(color: UIColor) {
+        containerView.backgroundColor = color
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/TCAT/Views/RoundShadowedView.swift
+++ b/TCAT/Views/RoundShadowedView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class RoundShadowedView: UIView {
 
-    private var containerView: UIView!
+    var containerView: UIView!
 
     init(cornerRadius: CGFloat) {
         super.init(frame: .zero)


### PR DESCRIPTION
## Overview

Present notification banner as confirmation when user turns notification switch on


## Changes Made

- Create a custom view `NotificationBannerView` for the notification banner
- Display banner whenever `notificationSwitch` is on 

## Test Coverage

Visually tested

## Next Steps (delete if not applicable)

Set up push notification


## Screenshots (delete if not applicable)

<details>

  <summary>Banner confirming notification for before boarding</summary>

<img src="https://user-images.githubusercontent.com/48968041/69203056-5fedf000-0b11-11ea-902d-f5ba0f302cd2.png" width="300" > 

</details>

<details>

  <summary>Banner confirming notification for delay </summary>

<img src="https://user-images.githubusercontent.com/48968041/69203037-5795b500-0b11-11ea-8fc9-9fcd10e8f404.png" width="300" > 

  </details>
