### PR TITLE
Fixes map snapping behavior on route detail

### DIFF
--- a/TCAT/Controllers/RouteDetail+ContentViewController.swift
+++ b/TCAT/Controllers/RouteDetail+ContentViewController.swift
@@ -78,11 +78,6 @@ class RouteDetailContentViewController: UIViewController {
         drawMapRoute()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        centerMapOnOverview(drawerPreviewing: true)
-    }
-
     /// Construct Directions based on Route and parse Waypoint / Path data
     func initializeRoute(_ route: Route, _ currentLocation: CLLocationCoordinate2D?) {
         self.route = route

--- a/TCAT/Controllers/RouteDetail+DrawerViewController.swift
+++ b/TCAT/Controllers/RouteDetail+DrawerViewController.swift
@@ -49,6 +49,7 @@ class RouteDetailDrawerViewController: UIViewController {
     var summaryView: SummaryView!
     let tableView = UITableView(frame: .zero, style: .grouped)
 
+    var currentPulleyPosition: PulleyPosition?
     var directionsAndVisibleStops: [RouteDetailItem] = []
     var expandedDirections: Set<Direction> = []
     var sections: [Section] = []

--- a/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
@@ -109,7 +109,7 @@ extension RouteDetailDrawerViewController: PulleyDrawerViewControllerDelegate {
     func drawerPositionDidChange(drawer: PulleyViewController, bottomSafeArea: CGFloat) {
         // Center map on drawer change
         let drawerPosition = drawer.drawerPosition
-        guard drawerPosition != currentPulleyPosition else { print("same position"); return }
+        guard drawerPosition != currentPulleyPosition else { return }
 
         currentPulleyPosition = drawerPosition
 

--- a/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
+++ b/TCAT/Controllers/RouteDetailDrawerViewController+Extensions.swift
@@ -108,7 +108,12 @@ extension RouteDetailDrawerViewController: PulleyDrawerViewControllerDelegate {
 
     func drawerPositionDidChange(drawer: PulleyViewController, bottomSafeArea: CGFloat) {
         // Center map on drawer change
-        switch drawer.drawerPosition {
+        let drawerPosition = drawer.drawerPosition
+        guard drawerPosition != currentPulleyPosition else { print("same position"); return }
+
+        currentPulleyPosition = drawerPosition
+
+        switch drawerPosition {
         case .collapsed, .partiallyRevealed:
             guard let contentViewController = drawer.primaryContentViewController as? RouteDetailContentViewController
                 else { return }
@@ -120,7 +125,7 @@ extension RouteDetailDrawerViewController: PulleyDrawerViewControllerDelegate {
                 }
                 selectedDirection = nil
             } else {
-                contentViewController.centerMapOnOverview(drawerPreviewing: drawer.drawerPosition == .partiallyRevealed)
+                contentViewController.centerMapOnOverview(drawerPreviewing: drawerPosition == .partiallyRevealed)
             }
         default: break
         }


### PR DESCRIPTION
<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Fixes the really annoying snapping behavior on Route Detail which prevented users from looking anywhere else on the map

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

We were centering the map each time `drawerPositionDidChange` was called even though the pulley position did not actually changed. I fixed this by keeping track of the `currentPulleyPosition`

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Played w/ the app




## Related PRs or Issues (delete if not applicable)

<!-- List related PRs against other branches/repositories. -->

Issue #355 

## Screenshots (delete if not applicable)

<!-- This could include of screenshots of the new feature / proof that the changes work. -->


  <summary>I actually don't know why the GIF gets cut off, my video file is actually a lot longer and shows the map 👀 </summary>

![ezgif com-video-to-gif-6](https://user-images.githubusercontent.com/26048121/74118476-8e67ee00-4b89-11ea-8d57-a07d44379388.gif)
  
