### PR TITLE
Integrates AppDevAnnouncements cocoapod and adds logging

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -34,6 +34,7 @@ target 'TCAT' do
     pod 'WhatsNewKit', '~> 1.1'
 
     # Other
+    pod 'AppDevAnnouncements', :git => 'https://github.com/cuappdev/appdev-announcements.git'
     pod 'SwiftLint'
     
     target 'TCATTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - AppDevAnnouncements (0.0.1)
   - Crashlytics (3.14.0):
     - Fabric (~> 1.10.2)
   - DZNEmptyDataSet (1.8.1)
@@ -86,6 +87,7 @@ PODS:
   - Zip (1.1.0)
 
 DEPENDENCIES:
+  - AppDevAnnouncements (from `https://github.com/cuappdev/appdev-announcements.git`)
   - Crashlytics (~> 3.12)
   - DZNEmptyDataSet (from `https://github.com/cuappdev/DZNEmptyDataSet.git`)
   - Fabric (~> 1.9)
@@ -129,6 +131,8 @@ SPEC REPOS:
     - Zip
 
 EXTERNAL SOURCES:
+  AppDevAnnouncements:
+    :git: https://github.com/cuappdev/appdev-announcements.git
   DZNEmptyDataSet:
     :git: https://github.com/cuappdev/DZNEmptyDataSet.git
   FutureNova:
@@ -137,6 +141,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/cuappdev/Presentation.git
 
 CHECKOUT OPTIONS:
+  AppDevAnnouncements:
+    :commit: 31c4502ac6e9e77e3c478bc46b4e4960cfc90fe9
+    :git: https://github.com/cuappdev/appdev-announcements.git
   DZNEmptyDataSet:
     :commit: a4a007e7ade7d9711f067f4d6510085fa1d92629
     :git: https://github.com/cuappdev/DZNEmptyDataSet.git
@@ -148,6 +155,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/cuappdev/Presentation.git
 
 SPEC CHECKSUMS:
+  AppDevAnnouncements: da6074ec0011c8964caa11cabc959ca007cb958f
   Crashlytics: 540b7e5f5da5a042647227a5e3ac51d85eed06df
   DZNEmptyDataSet: b94434220f87d9dda46660eb4f07a424778e93b4
   Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
@@ -175,6 +183,6 @@ SPEC CHECKSUMS:
   Wormholy: db6ac46a6d20db2d11ddcf975a5a9bcc1abc889e
   Zip: 8877eede3dda76bcac281225c20e71c25270774c
 
-PODFILE CHECKSUM: 74f5baec712c32e17985650cbe8dc20c43556af2
+PODFILE CHECKSUM: 07932619e4e861bbcd832b42f9dd7c6b53e09b3a
 
 COCOAPODS: 1.8.4

--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -1038,6 +1038,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-TCAT/Pods-TCAT-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/AppDevAnnouncements/AppDevAnnouncements.framework",
 				"${BUILT_PRODUCTS_DIR}/DZNEmptyDataSet/DZNEmptyDataSet.framework",
 				"${BUILT_PRODUCTS_DIR}/FutureNova/FutureNova.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
@@ -1054,6 +1055,7 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppDevAnnouncements.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DZNEmptyDataSet.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FutureNova.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",

--- a/TCAT/AppDelegate.swift
+++ b/TCAT/AppDelegate.swift
@@ -42,9 +42,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         FirebaseApp.configure()
 
         #if DEBUG
-            GMSServices.provideAPIKey(Keys.googleMapsDebug.value)
+        GMSServices.provideAPIKey(Keys.googleMapsDebug.value)
         #else
-            GMSServices.provideAPIKey(Keys.googleMapsRelease.value)
+        GMSServices.provideAPIKey(Keys.googleMapsRelease.value)
         #endif
 
         // Update shortcut items

--- a/TCAT/AppDelegate.swift
+++ b/TCAT/AppDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 cuappdev. All rights reserved.
 //
 
+import AppDevAnnouncements
 import Crashlytics
 import Fabric
 import Firebase
@@ -51,7 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Set Up Analytics
         #if !DEBUG
-            Crashlytics.start(withAPIKey: Keys.fabricAPIKey.value)
+        Crashlytics.start(withAPIKey: Keys.fabricAPIKey.value)
         #endif
 
         // Log basic information
@@ -89,9 +90,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let navigationController = showOnboarding ? OnboardingNavigationController(rootViewController: rootVC) :
             CustomNavigationController(rootViewController: rootVC)
 
+        // Setup networking for AppDevAnnouncements
+        AnnouncementNetworking.setupConfig(
+            scheme: Keys.announcementsScheme.value,
+            host: Keys.announcementsHost.value,
+            commonPath: Keys.announcementsCommonPath.value,
+            announcementPath: Keys.announcementsPath.value
+        )
+
         // Initalize window without storyboard
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        self.window!.rootViewController = navigationController
+        self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
 
         return true
@@ -115,8 +124,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let shortcutData = item.userInfo as? [String: Data] {
             guard let place = shortcutData["place"],
                 let destination = try? decoder.decode(Place.self, from: place) else {
-                print("[AppDelegate] Unable to access shortcutData['place']")
-                return
+                    print("[AppDelegate] Unable to access shortcutData['place']")
+                    return
             }
             let optionsVC = RouteOptionsViewController(searchTo: destination)
             if let navController = window?.rootViewController as? CustomNavigationController {
@@ -198,10 +207,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let lat = items?.filter({ $0.name == "lat" }).first?.value,
                 let long = items?.filter({ $0.name == "long" }).first?.value,
                 let stop = items?.filter({ $0.name == "stopName" }).first?.value {
-                    latitude = Double(lat)
-                    longitude = Double(long)
-                    stopName = stop
-                }
+                latitude = Double(lat)
+                longitude = Double(long)
+                stopName = stop
+            }
 
             if let latitude = latitude, let longitude = longitude, let stopName = stopName {
                 let place = Place(name: stopName, type: .busStop, latitude: latitude, longitude: longitude)

--- a/TCAT/Controllers/ParentHomeViewController.swift
+++ b/TCAT/Controllers/ParentHomeViewController.swift
@@ -6,13 +6,21 @@
 //  Copyright © 2019 cuappdev. All rights reserved.
 //
 
-import UIKit
+import AppDevAnnouncements
 import Pulley
+import UIKit
 
 class ParentHomeMapViewController: PulleyViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Present announcement if there are any new ones to present
+        presentAnnouncement { presented in
+            if presented {
+                Analytics.shared.log(AnnouncementPresentedPayload())
+            }
+        }
     }
 
     required init(contentViewController: UIViewController, drawerViewController: UIViewController) {

--- a/TCAT/Supporting Files/Keys.swift
+++ b/TCAT/Supporting Files/Keys.swift
@@ -10,6 +10,11 @@ import Foundation
 
 enum Keys: String {
 
+    case announcementsCommonPath = "announcements-common-path"
+    case announcementsHost = "announcements-host"
+    case announcementsPath = "announcements-path"
+    case announcementsScheme = "announcements-scheme"
+
     case fabricAPIKey = "fabric-api-key"
     case fabricBuildSecret = "fabric-build-secret"
 

--- a/TCAT/Utilities/Analytics.swift
+++ b/TCAT/Utilities/Analytics.swift
@@ -227,3 +227,8 @@ struct SearchResultSelectedPayload: Payload {
     let selectedIndex: Int
     let totalResults: Int
 }
+
+/// Log whenever an announcement is presented to the user
+struct AnnouncementPresentedPayload: Payload {
+    static let eventName = "announcement_presented"
+}


### PR DESCRIPTION
## Overview

<!-- Summarize your changes here. -->
This PR integrates the `AppDevAnnouncements` cocoapod & adds logging


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- Adds setup for `AppDevAnnouncements` into `AppDelegate.swift`
- Presents new announcements upon startup of the app if there are any new ones to present
- Added new keys to `TCAT/Supporting Files/Keys.plist`


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Ran the app and made sure that new announcements get displayed and that they only get shown once.


## Screenshots (delete if not applicable)

<!-- This could include of screenshots of the new feature / proof that the changes work. -->
Right now the only active announcement is on Eatery so I don't have a demo video except for the one on Eatery.
<details>

![2020-02-22 01 12 04](https://user-images.githubusercontent.com/26048121/75087611-ac7e0880-5510-11ea-9209-1625cf55080c.gif)
  

</details>
