### PR TITLE
Uncheck debug box

### DIFF
--- a/TCAT.xcodeproj/xcshareddata/xcschemes/TCAT Release.xcscheme
+++ b/TCAT.xcodeproj/xcshareddata/xcschemes/TCAT Release.xcscheme
@@ -41,8 +41,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
## Overview

Unchecked the debug box so that the Crashlytics report goes through when testing on a computer simulator.



## Changes Made

Unchecked the debug box in edit schemes