### PR TITLE
Quick boom fix

### DIFF
--- a/TCAT.xcodeproj/project.pbxproj
+++ b/TCAT.xcodeproj/project.pbxproj
@@ -1021,7 +1021,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.tcat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1118,7 +1118,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -DDEBUG";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "$(inherited) \"-D\" \"COCOAPODS\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.tcat.debug;
@@ -1217,7 +1217,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -DLOCAL";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "$(inherited) \"-D\" \"COCOAPODS\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.tcat.debug;

--- a/TCAT/Network/Endpoints.swift
+++ b/TCAT/Network/Endpoints.swift
@@ -42,8 +42,8 @@ extension Endpoint {
             originName: start.name,
             uid: uid
         )
-
-        return Endpoint(path: Constants.Endpoints.getRoutes, body: body)
+        // MARK: - Temporary fix for Boom
+        return Endpoint(path: "/api/v2"+Constants.Endpoints.getRoutes, body: body, useCommonPath: false)
     }
 
     static func getMultiRoutes(


### PR DESCRIPTION
## Overview

Quick boom fix

## Changes Made

### Change 1
This is a one line fix to use an old endpoint to make the app functional for boom.

## Test Coverage
Manual Testing

## Next Steps (optional)

Switch make to new endpoint and make the model so that it can handle null routes

## Screenshots (optional)

Route view
![Simulator Screenshot - iPhone 15 Pro - 2024-04-18 at 14 19 20](https://github.com/cuappdev/ithaca-transit-ios/assets/46629787/e98393e9-bbf7-49a2-8351-0adfb06b2d56)
