### PR TITLE
Fixed cancel button bug

### DIFF
--- a/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
+++ b/TCAT/Controllers/HomeOptionsCardViewController+Extensions.swift
@@ -19,6 +19,8 @@ extension HomeOptionsCardViewController {
         // Update searchbar attributes
         searchBar.placeholder = Constants.General.searchPlaceholder
         searchBar.text = nil
+        searchBar.setShowsCancelButton(false, animated: true)
+        animateInInfoButton()
 
         NotificationCenter.default.addObserver(
             self,


### PR DESCRIPTION
## Overview
When the route options view is opened and then the back button is clicked, the cancel button was still showing in the search bar in the HomeOptions view. This is now fixed, the info button now appears rather than the cancel button.

## Changes Made


### Change 1
- Changed the viewWillAppear method to make the cancel button not appear and the info button to animate into view.

## Test Coverage

- Moved back and forth between the Routes and HomeOptions views. Works as expected.

## Screenshots (optional)

https://github.com/user-attachments/assets/e7ad92c8-2d0b-4da2-8f21-edcf372a63b1

